### PR TITLE
Add Option To Fix Relative Urls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /node_modules
+.idea/

--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ By default, the style-loader appends `<style>` elements to the end of the `<head
 
 If defined, the style-loader will re-use a single `<style>` element, instead of adding/removing individual elements for each required module. **Note:** this option is on by default in IE9, which has strict limitations on the number of style tags allowed on a page. You can enable or disable it with the singleton query parameter (`?singleton` or `?-singleton`).
 
+#### `fixUrls`
+
+If fixUrls and sourceMaps are both enabled, relative urls will be converted to absolute urls right before the css is injected into the page. This resolves [an issue](https://github.com/webpack/style-loader/pull/96) where relative resources fail to load when source maps are enabled.  You can enable it with the fixUrls query parameter (`?fixUrls`).
+
 ## Recommended configuration
 
 By convention the reference-counted API should be bound to `.useable.css` and the simple API to `.css` (similar to other file types, i.e. `.useable.less` and `.less`).
@@ -72,7 +76,7 @@ So the recommended configuration for webpack is:
 }
 ```
 
-**Note** about source maps support and assets referenced with `url`: when style loader is used with ?sourceMap option, the CSS modules will be generated as `Blob`s, so relative paths don't work (they would be relative to `chrome:blob` or `chrome:devtools`). In order for assets to maintain correct paths setting `output.publicPath` property of webpack configuration must be set, so that absolute paths are generated.
+**Note** about source maps support and assets referenced with `url`: when style loader is used with ?sourceMap option, the CSS modules will be generated as `Blob`s, so relative paths don't work (they would be relative to `chrome:blob` or `chrome:devtools`). In order for assets to maintain correct paths setting `output.publicPath` property of webpack configuration must be set, so that absolute paths are generated. Alternatively you can enable the `fixUrls` option mentioned above.
 
 ## Install
 

--- a/addStyles.js
+++ b/addStyles.js
@@ -18,7 +18,8 @@ var stylesInDom = {},
 	}),
 	singletonElement = null,
 	singletonCounter = 0,
-	styleElementsInsertedAtTop = [];
+	styleElementsInsertedAtTop = [],
+	fixUrls = require("./fixUrls");
 
 module.exports = function(list, options) {
 	if(typeof DEBUG !== "undefined" && DEBUG) {
@@ -32,6 +33,9 @@ module.exports = function(list, options) {
 
 	// By default, add <style> tags to the bottom of <head>.
 	if (typeof options.insertAt === "undefined") options.insertAt = "bottom";
+
+	// Fix urls defaults to false
+	if (typeof options.fixUrls === "undefined") options.fixUrls = false;
 
 	var styles = listToStyles(list);
 	addStylesToDom(styles, options);
@@ -155,7 +159,7 @@ function addStyle(obj, options) {
 		typeof Blob === "function" &&
 		typeof btoa === "function") {
 		styleElement = createLinkElement(options);
-		update = updateLink.bind(null, styleElement);
+		update = updateLink.bind(null, styleElement, options);
 		remove = function() {
 			removeStyleElement(styleElement);
 			if(styleElement.href)
@@ -226,9 +230,13 @@ function applyToTag(styleElement, obj) {
 	}
 }
 
-function updateLink(linkElement, obj) {
+function updateLink(linkElement, options, obj) {
 	var css = obj.css;
 	var sourceMap = obj.sourceMap;
+
+	if (options.fixUrls){
+		css = fixUrls(css);
+	}
 
 	if(sourceMap) {
 		// http://stackoverflow.com/a/26603875

--- a/fixUrls.js
+++ b/fixUrls.js
@@ -1,0 +1,58 @@
+
+/**
+ * When source maps are enabled, `style-loader` uses a link element with a data-uri to
+ * embed the css on the page. This breaks all relative urls because now they are relative to a
+ * bundle instead of the current page.
+ *
+ * One solution is to only use full urls, but that may be impossible.
+ *
+ * Instead, this function "fixes" the relative urls to be absolute according to the current page location.
+ *
+ * A rudimentary test suite is located at `test/fixUrls.js` and can be run via the `npm test` command.
+ *
+ */
+
+module.exports = function (css, currentUrl) {
+
+	// get current url
+	currentUrl = currentUrl || (typeof window !== "undefined" && window.location && window.location.href) || null;
+	if (typeof currentUrl != "string") {
+		throw new Error("fixUrls requires a current url");
+	}
+
+	//blank or null?
+	if (!css || typeof css !== "string")
+	  return css;
+
+	//base url
+	var baseUrl = currentUrl.match(/^([a-z]+:)?(\/\/)?[^\/]+/)[0];
+	var currentUrlPath = baseUrl + (currentUrl.replace(baseUrl, "")).replace(/\/[^\/]+$/, "") + "/";
+
+	//convert each url(...)
+	var fixedCss = css.replace(/url *\( *(.+?) *\)/g, function(fullMatch, origUrl){
+		//strip quotes (if they exist)
+		var unquotedOrigUrl = origUrl
+			.replace(/^"(.*)"$/, function(o,$1){ return $1; })
+			.replace(/^'(.*)'$/, function(o,$1){ return $1; });
+
+		//already a full url? no change
+		if (/^(data:|http:\/\/|https:\/\/|file:\/\/\/|\/\/)/i.test(unquotedOrigUrl))
+		  return fullMatch;
+
+		//convert the url to a full url
+		var newUrl = unquotedOrigUrl;
+		if (newUrl.indexOf("/") === 0){
+			//path should be relative to the base url
+			newUrl = baseUrl + newUrl;
+		}else{
+			//path should be relative to the current directory
+			newUrl = currentUrlPath + newUrl.replace(/^\.\//, "");
+		}
+
+		//send back the fixed url(...)
+		return "url("+JSON.stringify(newUrl)+")";
+	});
+
+	//send back the fixed css
+	return fixedCss;
+};

--- a/fixUrls.js
+++ b/fixUrls.js
@@ -26,6 +26,7 @@ module.exports = function (css, currentUrl) {
 
 	//base url
 	var baseUrl = currentUrl.match(/^([a-z]+:)?(\/\/)?[^\/]+/)[0];
+	var protocol = baseUrl.split(":")[0];
 	var currentUrlPath = baseUrl + (currentUrl.replace(baseUrl, "")).replace(/\/[^\/]+$/, "") + "/";
 
 	//convert each url(...)
@@ -36,12 +37,15 @@ module.exports = function (css, currentUrl) {
 			.replace(/^'(.*)'$/, function(o,$1){ return $1; });
 
 		//already a full url? no change
-		if (/^(data:|http:\/\/|https:\/\/|file:\/\/\/|\/\/)/i.test(unquotedOrigUrl))
+		if (/^(data:|http:\/\/|https:\/\/|file:\/\/\/)/i.test(unquotedOrigUrl))
 		  return fullMatch;
 
 		//convert the url to a full url
 		var newUrl = unquotedOrigUrl;
-		if (newUrl.indexOf("/") === 0){
+		if (newUrl.indexOf("//") === 0) {
+		  //add protocol
+			newUrl = protocol + ":" +newUrl;
+		}else if (newUrl.indexOf("/") === 0){
 			//path should be relative to the base url
 			newUrl = baseUrl + newUrl;
 		}else{

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.13.1",
   "author": "Tobias Koppers @sokra",
   "description": "style loader module for webpack",
+  "scripts": {
+    "test": "node test"
+  },
   "devDependencies": {
     "css-loader": "~0.8.0"
   },

--- a/test/fixUrls.js
+++ b/test/fixUrls.js
@@ -41,7 +41,6 @@ module.exports = function () {
   assert("Https url isn't changed", "body { background-image:url(https://example.com/bg.jpg); }");
   assert("HTTPS url isn't changed", "body { background-image:url(HTTPS://example.com/bg.jpg); }");
   assert("File url isn't changed", "body { background-image:url(file:///example.com/bg.jpg); }");
-  assert("Double slash url isn't changed", "body { background-image:url(//example.com/bg.jpg); }");
   assert("Image data uri url isn't changed", "body { background-image:url(data:image/png;base64,qsrwABYuwNkimqm3gAAAABJRU5ErkJggg==); }");
   assert("Font data uri url isn't changed", "body { background-image:url(data:application/x-font-woff;charset=utf-8;base64,qsrwABYuwNkimqm3gAAAABJRU5ErkJggg); }");
 
@@ -55,6 +54,10 @@ module.exports = function () {
   // rooted urls
   assert("Rooted url", "body { background-image:url(/bg.jpg); }", "body { background-image:url(\"https://x.y.z/bg.jpg\"); }");
   assert("Rooted url with path", "body { background-image:url(/a/b/bg.jpg); }", "body { background-image:url(\"https://x.y.z/a/b/bg.jpg\"); }");
+
+  // protocol-less urls are fixed
+  assert("Absolute urls without protocol are fixed, http", "body { background-image:url(//example.com/s/bg.jpg); }", "body { background-image:url(\"http://example.com/s/bg.jpg\"); }", "http://someothersite.com");
+  assert("Absolute urls without protocol are fixed, https", "body { background-image:url(//example.com/s/bg.jpg); }", "body { background-image:url(\"https://example.com/s/bg.jpg\"); }", "https://someothersite.com");
 
   //special locations
   assert("Location with no path, filename only", "body { background-image:url(bg.jpg); }", "body { background-image:url(\"http://x.y.z/bg.jpg\"); }", "http://x.y.z");

--- a/test/fixUrls.js
+++ b/test/fixUrls.js
@@ -1,0 +1,78 @@
+
+
+var fixUrls = require("../fixUrls");
+
+var currentUrl = "https://x.y.z/a/b.html";
+
+var logs = [];
+var numberOfErrors = 0;
+
+var assert = function (title, origCss, expectedCss, specialUrl) {
+  var resultCss = fixUrls(origCss, specialUrl || currentUrl);
+  expectedCss = expectedCss || origCss;
+
+  if (resultCss === expectedCss) {
+    logs.push("OK: " + title);
+  }else{
+    logs.push("\nERROR: " + title+"\nRESULT\n"+resultCss+"\nEXPECTED:\n"+expectedCss+"\n");
+    numberOfErrors += 1;
+  }
+};
+
+var finish = function () {
+  console.log(logs.join("\n"));
+  if (numberOfErrors) { throw new Error(numberOfErrors + " ERRORS"); }
+};
+
+module.exports = function () {
+
+  // no change
+  assert("Null css is not modified", null);
+  assert("Blank css is not modified", "");
+  assert("No url is not modified", "body { }");
+  assert("Full url isn't changed (no quotes)", "body { background-image:url(http://example.com/bg.jpg); }");
+  assert("Full url isn't changed (no quotes, spaces)", "body { background-image:url ( http://example.com/bg.jpg  ); }");
+  assert("Full url isn't changed (double quotes)", "body { background-image:url(\"http://example.com/bg.jpg\"); }");
+  assert("Full url isn't changed (double quotes, spaces)", "body { background-image:url (  \"http://example.com/bg.jpg\" ); }");
+  assert("Full url isn't changed (single quotes)", "body { background-image:url('http://example.com/bg.jpg'); }");
+  assert("Full url isn't changed (single quotes, spaces)", "body { background-image:url ( 'http://example.com/bg.jpg'  ); }");
+  assert("Multiple full urls are not changed", "body { background-image:url(http://example.com/bg.jpg); }\ndiv.main { background-image:url ( 'https://www.anothersite.com/another.png' ); }");
+  assert("Http url isn't changed", "body { background-image:url(http://example.com/bg.jpg); }");
+  assert("Https url isn't changed", "body { background-image:url(https://example.com/bg.jpg); }");
+  assert("HTTPS url isn't changed", "body { background-image:url(HTTPS://example.com/bg.jpg); }");
+  assert("File url isn't changed", "body { background-image:url(file:///example.com/bg.jpg); }");
+  assert("Double slash url isn't changed", "body { background-image:url(//example.com/bg.jpg); }");
+  assert("Image data uri url isn't changed", "body { background-image:url(data:image/png;base64,qsrwABYuwNkimqm3gAAAABJRU5ErkJggg==); }");
+  assert("Font data uri url isn't changed", "body { background-image:url(data:application/x-font-woff;charset=utf-8;base64,qsrwABYuwNkimqm3gAAAABJRU5ErkJggg); }");
+
+  // relative urls
+  assert("Relative url", "body { background-image:url(bg.jpg); }", "body { background-image:url(\"https://x.y.z/a/bg.jpg\"); }");
+  assert("Relative url with path", "body { background-image:url(c/d/bg.jpg); }", "body { background-image:url(\"https://x.y.z/a/c/d/bg.jpg\"); }");
+  assert("Relative url with dot slash", "body { background-image:url(./c/d/bg.jpg); }", "body { background-image:url(\"https://x.y.z/a/c/d/bg.jpg\"); }");
+  assert("Multiple relative urls", "body { background-image:url(bg.jpg); }\ndiv.main { background-image:url(./c/d/bg.jpg); }", "body { background-image:url(\"https://x.y.z/a/bg.jpg\"); }\ndiv.main { background-image:url(\"https://x.y.z/a/c/d/bg.jpg\"); }");
+  assert("Relative url that looks like data-uri", "body { background-image:url(data/image/png.base64); }", "body { background-image:url(\"https://x.y.z/a/data/image/png.base64\"); }");
+
+  // rooted urls
+  assert("Rooted url", "body { background-image:url(/bg.jpg); }", "body { background-image:url(\"https://x.y.z/bg.jpg\"); }");
+  assert("Rooted url with path", "body { background-image:url(/a/b/bg.jpg); }", "body { background-image:url(\"https://x.y.z/a/b/bg.jpg\"); }");
+
+  //special locations
+  assert("Location with no path, filename only", "body { background-image:url(bg.jpg); }", "body { background-image:url(\"http://x.y.z/bg.jpg\"); }", "http://x.y.z");
+  assert("Location with no path, path with filename", "body { background-image:url(a/bg.jpg); }", "body { background-image:url(\"http://x.y.z/a/bg.jpg\"); }", "http://x.y.z");
+  assert("Location with no path, rel path with filename", "body { background-image:url(./a/bg.jpg); }", "body { background-image:url(\"http://x.y.z/a/bg.jpg\"); }", "http://x.y.z");
+  assert("Location with no path, root filename", "body { background-image:url(/a/bg.jpg); }", "body { background-image:url(\"http://x.y.z/a/bg.jpg\"); }", "http://x.y.z");
+
+  //location is required
+  try {
+    fixUrls("", null);
+    logs.push("ERROR: Current url must be required");
+    numberOfErrors += 1;
+  }catch(e){
+    logs.push("OK: Current url is required");
+  }
+
+  // finish up
+  finish();
+
+};
+

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,3 @@
+
+
+require("./fixUrls")();


### PR DESCRIPTION
When sourceMaps are enabled, relative urls stop working. This appears to be a pain point for a lot of people. ([Ref 1](https://github.com/webpack/style-loader/pull/96), [2](https://github.com/webpack/style-loader/issues/93), [3](https://github.com/webpack/style-loader/issues/55), [4](https://github.com/webpack/css-loader/issues/29), [5](https://github.com/webpack/file-loader/issues/29), [6](https://github.com/webpack/webpack-dev-server/issues/226), [7](https://github.com/coryhouse/react-slingshot/issues/81), [8](https://github.com/webpack/css-loader/issues/216), [9](http://stackoverflow.com/questions/31549268/webpack-css-loader-not-finding-images-within-url-reference-in-an-external-styl?rq=1), etc)

Basically `style-loader` uses a link data-uri to embed the css with a source map. That means relative urls have no way to resolve their path. 

Ideally urls should be converted to absolute urls before the `style-loader` runs, but that isn't always possible.  In my opinion `style-loader` is in a unique position to alleviate this issue.

This pull request creates an opt-in option `fixUrls`. When enabled, it uses regex to replace relative image/font urls with absolute urls according to the page location.

Ideally I'd parse the css, but client-side parsers look to be 40-80KB and would likely be a lot slower. Parsing has to happen client side because the location is not known until then.

I've included about 30 test (which can be run with `npm test`) to verify that relative urls are resolved properly, absolute urls are not touched, etc.
