### PR TITLE
Break the `sourceMappingURL` string to avoid confusing Chrome.

### DIFF
--- a/addStyles.js
+++ b/addStyles.js
@@ -232,7 +232,9 @@ function updateLink(linkElement, obj) {
 
 	if(sourceMap) {
 		// http://stackoverflow.com/a/26603875
-		css += "\n/*# sourceMappingURL=data:application/json;base64," + btoa(unescape(encodeURIComponent(JSON.stringify(sourceMap)))) + " */";
+		// The seemingly-unnecessary break between 'source' and 'Mapping' is to prevent Chrome 51 (at least) from
+		// trying to interpret this code as an actual source map reference.
+		css += "\n/*# source" + "MappingURL=data:application/json;base64," + btoa(unescape(encodeURIComponent(JSON.stringify(sourceMap)))) + " */";
 	}
 
 	var blob = new Blob([css], { type: "text/css" });


### PR DESCRIPTION
We recently started seeing "Failed to load SourceMap" problems loading in our app in Chrome 51.  I eventually tracked it down to this line in `style-loader`'s `addStyles.js`:

```
css += "\n/*# sourceMappingURL=data:application/json;base64," + btoa(unescape(encodeURIComponent(JSON.stringify(sourceMap)))) + " */";
```

I suspect that Chrome is incorrectly interpreting this as an actual sourcemap reference.  In any case, breaking up the `sourceMappingURL` solved the problem for us, so I hope you might consider merging this simple workaround!

For what it's worth, the problem does not occur in Chrome Canary, but that's not expected to hit stable until September or October.
