### PR TITLE
fix: avoid adding duplicate styles

### DIFF
--- a/addStyles.js
+++ b/addStyles.js
@@ -93,8 +93,6 @@ function listToStyles(list) {
 		var part = {css: css, media: media, sourceMap: sourceMap};
 		if(!newStyles[id])
 			styles.push(newStyles[id] = {id: id, parts: [part]});
-		else
-			newStyles[id].parts.push(part);
 	}
 	return styles;
 }


### PR DESCRIPTION
In a case where:
- Entry point includes A
- CSS file A includes B and C
  - CSS file C includes D
    - CSS file D also includes B

`addStylesToDom` would see B as having two identical parts, and thus it would get added twice to the head.

Removing the `else` branch here stops it from happening, and works locally.

I am not sure what the `parts` handling is for, though. In my case, the `list` has two instances of the same dependency (`list[0] === list[1]`), which results in duplicate inclusion; so it just results in adding two of the exact same style tag to the DOM.

I may also be doing something dumb, though for now I am merely testing a complex config rather than writing real css with that hierarchy. The `parts` handling was added at the same time as deduplication was, but I suppose the deduplication only works with linear dependency graphs.

In what case would `parts` with `length >= 1`  have something that is _not_ a duplicate?
