### PR TITLE
Add insertInto option

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,10 @@ Note: Behavior is undefined when `unuse`/`unref` is called more often than `use`
 
 #### `insertAt`
 
-By default, the style-loader appends `<style>` elements to the end of the `<head>` tag of the page. This will cause CSS created by the loader to take priority over CSS already present in the document head. To insert style elements at the beginning of the head, set this query parameter to 'top', e.g. `require('../style.css?insertAt=top')`.
+By default, the style-loader appends `<style>` elements to the end of the style target, which is the `<head>` tag of the page unless specified by `insertInto`. This will cause CSS created by the loader to take priority over CSS already present in the target. To insert style elements at the beginning of the target, set this query parameter to 'top', e.g. `require('../style.css?insertAt=top')`.
+
+#### `insertInto`
+By default, the style-loader inserts the `<style>` elements into the `<head>` tag of the page. If you want the tags to be inserted somewhere else, e.g. into a [ShadowRoot](https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot), you can specify a CSS selector for that element here, e.g. `require('../style.css?insertInto=#host::shadow>#root')`.
 
 #### `singleton`
 

--- a/test/basicTest.js
+++ b/test/basicTest.js
@@ -14,6 +14,7 @@ describe("basic tests", function() {
     localScopedCss = ":local(.className) { background: red; }",
     requiredStyle = `<style type="text/css">${requiredCss}</style>`,
     existingStyle = "<style>.existing { color: yellow }</style>",
+    checkValue = '<div class="check">check</div>',
     rootDir = path.resolve(__dirname + "/../") + "/",
     jsdomHtml = [
       "<html>",
@@ -21,6 +22,9 @@ describe("basic tests", function() {
       existingStyle,
       "</head>",
       "<body>",
+      "<div class='target'>",
+      checkValue,
+      "</div>",
       "</body>",
       "</html>"
     ].join("\n");
@@ -82,6 +86,15 @@ describe("basic tests", function() {
 
     runCompilerTest(expected, done);
   }); // it insert at top
+
+  it("insert into", function(done) {
+    let selector = "div.target";
+    styleLoaderOptions.insertInto = selector;
+
+    let expected = [checkValue, requiredStyle].join("\n");
+
+    runCompilerTest(expected, done, undefined, selector);
+  }); // it insert into
 
   it("singleton", function(done) {
     // Setup

--- a/test/utils.js
+++ b/test/utils.js
@@ -57,7 +57,8 @@ module.exports = {
    *  @param {function} done - Async callback from Mocha.
    *  @param {function} actual - Executed in the context of jsdom window, should return a string to compare to.
    */
-  runCompilerTest: function(expected, done, actual) {
+  runCompilerTest: function(expected, done, actual, selector) {
+    selector = selector || "head"
     compiler.run(function(err, stats) {
       if (stats.compilation.errors.length) {
         throw new Error(stats.compilation.errors);
@@ -73,7 +74,7 @@ module.exports = {
           if (typeof actual === 'function') {
             assert.equal(actual.apply(window), expected);  
           } else {
-            assert.equal(window.document.head.innerHTML.trim(), expected);
+            assert.equal(window.document.querySelector(selector).innerHTML.trim(), expected);
           }
           // free memory associated with the window
           window.close();


### PR DESCRIPTION
Add another option called `insertInto` - which allows specifying a CSS selector - e.g. `#styles` - to be used as an argument to `document.querySelector` to find an element into which to insert the generated `<style>`-tags. Will default to the `<head>`-tag if undefined.

This was created because I wanted to insert `<style>` tags into a ShadowRoot (like in #131), but this is not a specific solution for that, but does solve it by allowing people to first create a ShadowRoot and then target it using `insertInto` and the appropriate selector.

Not att all sure if this is wanted, but it exists, so there ya go :)
Also, I replaced the `getHeadElement` function with a custom memoized function rather than add the key feature to the existing memoizing function, not sure if that was the better choice, but it felt like it.

Closes #131 
