### PR TITLE
refactor: support force disabling sourcemaps and setting sourceRoot

### DIFF
--- a/addStyles.js
+++ b/addStyles.js
@@ -171,12 +171,17 @@ function attachTagAttrs(element, attrs) {
 function addStyle(obj, options) {
 	var styleElement, update, remove;
 
+	if (obj.sourceMap && typeof options.sourceRoot === "string") {
+		obj.sourceMap.sourceRoot = options.sourceRoot;
+	}
+
 	if (options.singleton) {
 		var styleIndex = singletonCounter++;
 		styleElement = singletonElement || (singletonElement = createStyleElement(options));
 		update = applyToSingletonTag.bind(null, styleElement, styleIndex, false);
 		remove = applyToSingletonTag.bind(null, styleElement, styleIndex, true);
 	} else if(obj.sourceMap &&
+		options.sourceMap !== false &&
 		typeof URL === "function" &&
 		typeof URL.createObjectURL === "function" &&
 		typeof URL.revokeObjectURL === "function" &&


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
feature

**Summary**
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
SourceMaps have so far been a real pain to track down the source of issues with, and the way CSS loaders handle them seem to be all over the place. Most of these stem from the `sourceRoot` property being set and then integrated into the actual source paths somewhere down the line. This is especially problematic if webpack isn't being run in the current working directory (as I am). As long as it's blank throughout though, things seem to work out.

However, once the maps arrive at `style-loader`, they have no root, and without one they get put under the `(no domain)` section in Chrome's Sources view. The `ExtractTextPlugin` handles these fine since the paths are set via `moduleFilenameTemplate`. I could write an intermediate loader just to set `sourceRoot` to `webpack:///`, but it would be nice if I could do that through `style-loader`'s config, which is the goal of this PR.

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
Nope!