### PR TITLE
feat: add option.base

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,15 @@ require('style-loader/url?{attrs:{prop: "value"}}!file-loader!style.css')
 // will create link tag <link rel="stylesheet" type="text/css" href="[path]/style.css" prop="value">
 ```
 
+#### `cssBase`
+This setting is primarily used as a workaround for [css clashes](https://github.com/webpack-contrib/style-loader/issues/163) when using one or more [DllPlugin](https://robertknight.github.io/posts/webpack-dll-plugins/)'s.  `cssBase` allows you to prevent either the *app*'s css (or *DllPlugin2*'s css) from overwriting *DllPlugin1*'s css by specifying a css module id base which is greater than the range used by *DllPlugin1* e.g.:
+* webpack.dll1.config.js
+    * `loaders:[ { test: /\.css$/, loader: 'style-loader!css-loader' } ]`
+* webpack.dll2.config.js
+    * `loaders:[ { test: /\.css$/, loader: 'style-loader?cssBase=1000!css-loader' } ]`
+* webpack.app.config.js
+    * `loaders:[ { test: /\.css$/, loader: 'style-loader?cssBase=2000!css-loader' } ]`
+
 ### Recommended configuration
 
 By convention the reference-counted API should be bound to `.useable.css` and the simple API to `.css` (similar to other file types, i.e. `.useable.less` and `.less`).

--- a/README.md
+++ b/README.md
@@ -98,11 +98,35 @@ require('style-loader/url?{attrs:{prop: "value"}}!file-loader!style.css')
 #### `cssBase`
 This setting is primarily used as a workaround for [css clashes](https://github.com/webpack-contrib/style-loader/issues/163) when using one or more [DllPlugin](https://robertknight.github.io/posts/webpack-dll-plugins/)'s.  `cssBase` allows you to prevent either the *app*'s css (or *DllPlugin2*'s css) from overwriting *DllPlugin1*'s css by specifying a css module id base which is greater than the range used by *DllPlugin1* e.g.:
 * webpack.dll1.config.js
-    * `loaders:[ { test: /\.css$/, loader: 'style-loader!css-loader' } ]`
+```
+{
+  test: /\.css$/,
+  use: [ 
+    'style-loader',
+    'css-loader'
+  ]
+}
+```
 * webpack.dll2.config.js
-    * `loaders:[ { test: /\.css$/, loader: 'style-loader?cssBase=1000!css-loader' } ]`
+```
+{
+  test: /\.css$/,
+  use: [ 
+    { loader: 'style-loader', options: { cssBase: 1000 } },
+    'css-loader'
+  ]
+}
+```
 * webpack.app.config.js
-    * `loaders:[ { test: /\.css$/, loader: 'style-loader?cssBase=2000!css-loader' } ]`
+```
+{
+  test: /\.css$/,
+  use: [ 
+    { loader: 'style-loader', options: { cssBase: 2000 } },
+    'css-loader'
+  ]
+}
+```
 
 ### Recommended configuration
 

--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ require('style-loader/url?{attrs:{prop: "value"}}!file-loader!style.css')
 // will create link tag <link rel="stylesheet" type="text/css" href="[path]/style.css" prop="value">
 ```
 
-#### `cssBase`
-This setting is primarily used as a workaround for [css clashes](https://github.com/webpack-contrib/style-loader/issues/163) when using one or more [DllPlugin](https://robertknight.github.io/posts/webpack-dll-plugins/)'s.  `cssBase` allows you to prevent either the *app*'s css (or *DllPlugin2*'s css) from overwriting *DllPlugin1*'s css by specifying a css module id base which is greater than the range used by *DllPlugin1* e.g.:
+#### `base`
+This setting is primarily used as a workaround for [css clashes](https://github.com/webpack-contrib/style-loader/issues/163) when using one or more [DllPlugin](https://robertknight.github.io/posts/webpack-dll-plugins/)'s.  `base` allows you to prevent either the *app*'s css (or *DllPlugin2*'s css) from overwriting *DllPlugin1*'s css by specifying a css module id base which is greater than the range used by *DllPlugin1* e.g.:
 * webpack.dll1.config.js
 ```
 {
@@ -112,7 +112,7 @@ This setting is primarily used as a workaround for [css clashes](https://github.
 {
   test: /\.css$/,
   use: [ 
-    { loader: 'style-loader', options: { cssBase: 1000 } },
+    { loader: 'style-loader', options: { base: 1000 } },
     'css-loader'
   ]
 }
@@ -122,7 +122,7 @@ This setting is primarily used as a workaround for [css clashes](https://github.
 {
   test: /\.css$/,
   use: [ 
-    { loader: 'style-loader', options: { cssBase: 2000 } },
+    { loader: 'style-loader', options: { base: 2000 } },
     'css-loader'
   ]
 }

--- a/addStyles.js
+++ b/addStyles.js
@@ -105,7 +105,7 @@ function listToStyles(list, options) {
 	var newStyles = {};
 	for(var i = 0; i < list.length; i++) {
 		var item = list[i];
-		var id = options.cssBase ? item[0] + options.cssBase : item[0];
+		var id = options.base ? item[0] + options.base : item[0];
 		var css = item[1];
 		var media = item[2];
 		var sourceMap = item[3];

--- a/addStyles.js
+++ b/addStyles.js
@@ -105,7 +105,7 @@ function listToStyles(list, options) {
 	var newStyles = {};
 	for(var i = 0; i < list.length; i++) {
 		var item = list[i];
-		var id = item[0] + (options.cssBase || 0);
+		var id = item[0] + (+(options.cssBase || 0));
 		var css = item[1];
 		var media = item[2];
 		var sourceMap = item[3];

--- a/addStyles.js
+++ b/addStyles.js
@@ -105,7 +105,7 @@ function listToStyles(list, options) {
 	var newStyles = {};
 	for(var i = 0; i < list.length; i++) {
 		var item = list[i];
-		var id = item[0] + (+(options.cssBase || 0));
+		var id = options.cssBase ? item[0] + options.cssBase : item[0];
 		var css = item[1];
 		var media = item[2];
 		var sourceMap = item[3];

--- a/addStyles.js
+++ b/addStyles.js
@@ -52,7 +52,7 @@ module.exports = function(list, options) {
 	// By default, add <style> tags to the bottom of the target
 	if (typeof options.insertAt === "undefined") options.insertAt = "bottom";
 
-	var styles = listToStyles(list);
+	var styles = listToStyles(list, options);
 	addStylesToDom(styles, options);
 
 	return function update(newList) {
@@ -64,7 +64,7 @@ module.exports = function(list, options) {
 			mayRemove.push(domStyle);
 		}
 		if(newList) {
-			var newStyles = listToStyles(newList);
+			var newStyles = listToStyles(newList, options);
 			addStylesToDom(newStyles, options);
 		}
 		for(var i = 0; i < mayRemove.length; i++) {
@@ -100,12 +100,12 @@ function addStylesToDom(styles, options) {
 	}
 }
 
-function listToStyles(list) {
+function listToStyles(list, options) {
 	var styles = [];
 	var newStyles = {};
 	for(var i = 0; i < list.length; i++) {
 		var item = list[i];
-		var id = item[0];
+		var id = item[0] + (options.cssBase || 0);
 		var css = item[1];
 		var media = item[2];
 		var sourceMap = item[3];


### PR DESCRIPTION
…loader/issues/163

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
bugfix / workaround for https://github.com/webpack/style-loader/issues/163

**Did you add tests for your changes?**
no

**If relevant, did you update the README?**
no

**Summary**
This is a workaround. It allows the user to manually specify base id's for each bundle when multiple bundles are used on a page. The user would for have to manually specify the order in various webpack.configs like so:
dll1.js
`loaders:[ { test: /\.css$/, loader: 'style-loader!css-loader' } ]`
dll2.js
`loaders:[ { test: /\.css$/, loader: 'style-loader?cssBase=1000!css-loader' } ]`
app.js
`loaders:[ { test: /\.css$/, loader: 'style-loader?cssBase=2000!css-loader' } ]`

see https://github.com/webpack/style-loader/issues/163

**Does this PR introduce a breaking change?**
no - the user has to opt in - there's no impact if the user doesn't specify `option.cssBase`

**Other information**
