### PR TITLE
refactor: modifying source map support to also support relative urls in stylesheets

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,15 @@
+<!-- Before creating an issue please make sure you are using the latest version of style-loader. -->
+
+**Do you want to request a *feature* or report a *bug*?**
+<!-- Please ask questions on StackOverflow or the webpack Gitter (https://gitter.im/webpack/webpack). Questions will be closed. -->
+
+**What is the current behavior?**
+
+**If the current behavior is a bug, please provide the steps to reproduce.**
+<!-- A great way to do this is to provide your configuration via a GitHub gist. -->
+
+**What is the expected behavior?**
+
+**If this is a feature request, what is motivation or use case for changing the behavior?**
+
+**Please mention other relevant information such as your webpack version, Node.js version and Operating System.**

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
+
+**What kind of change does this PR introduce?**
+<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
+
+**Did you add tests for your changes?**
+
+**If relevant, did you update the README?**
+
+**Summary**
+
+<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
+<!-- Try to link to an open issue for more information. -->
+
+**Does this PR introduce a breaking change?**
+<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
+
+**Other information**

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,20 @@
+Copyright JS Foundation and other contributors
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -95,8 +95,6 @@ So the recommended configuration for webpack is:
 }
 ```
 
-**Note** about source maps support and assets referenced with `url`: when style loader is used with ?sourceMap option, the CSS modules will be generated as `Blob`s, so relative paths don't work (they would be relative to `chrome:blob` or `chrome:devtools`). In order for assets to maintain correct paths setting `output.publicPath` property of webpack configuration must be set, so that absolute paths are generated.
-
 ## License
 
 MIT (http://www.opensource.org/licenses/mit-license.php)

--- a/addStyles.js
+++ b/addStyles.js
@@ -11,7 +11,7 @@ var stylesInDom = {},
 		};
 	},
 	isOldIE = memoize(function() {
-		return /msie [6-9]\b/.test(window.navigator.userAgent.toLowerCase());
+		return /msie [6-9]\b/.test(self.navigator.userAgent.toLowerCase());
 	}),
 	getHeadElement = memoize(function () {
 		return document.head || document.getElementsByTagName("head")[0];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "style-loader",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "author": "Tobias Koppers @sokra",
   "description": "style loader module for webpack",
   "devDependencies": {


### PR DESCRIPTION
Fixing broken relative and protocol-relative url() use in stylesheets when source maps are enabled. Chrome Canary 57.0.2981.0 and Firefox 50.1.0 support loading source maps when sourceMapURL directive is dynamically added to a new or existing style element in the DOM. This means that style-loader can simply add the styles and sourceMapURL directive as text inside a style element and the source map will be loaded by the browser. Given the simpler insertion method, the relative and protocol-relative urls in stylesheets will not break.

Plenty of discussion on this bug in #124. This PR would be great to merge in once browser support is at an acceptable level. Currently Chrome Canary 57.0.2981.0 and Firefox 50.1.0 work with this source map support.

README updated to remove the warning about source maps and relative urls in styles breaking.