### PR TITLE
refactor: use es2015 modules

### DIFF
--- a/addStyles.js
+++ b/addStyles.js
@@ -20,7 +20,7 @@ var stylesInDom = {},
 	singletonCounter = 0,
 	styleElementsInsertedAtTop = [];
 
-module.exports = function(list, options) {
+module.exports = function(object, options) {
 	if(typeof DEBUG !== "undefined" && DEBUG) {
 		if(typeof document !== "object") throw new Error("The style-loader cannot be used in a non-browser environment");
 	}
@@ -33,10 +33,10 @@ module.exports = function(list, options) {
 	// By default, add <style> tags to the bottom of <head>.
 	if (typeof options.insertAt === "undefined") options.insertAt = "bottom";
 
-	var styles = listToStyles(list);
+	var styles = objectToStyles(object);
 	addStylesToDom(styles, options);
 
-	return function update(newList) {
+	return function update(newObject) {
 		var mayRemove = [];
 		for(var i = 0; i < styles.length; i++) {
 			var item = styles[i];
@@ -44,8 +44,8 @@ module.exports = function(list, options) {
 			domStyle.refs--;
 			mayRemove.push(domStyle);
 		}
-		if(newList) {
-			var newStyles = listToStyles(newList);
+		if(newObject) {
+			var newStyles = objectToStyles(newObject);
 			addStylesToDom(newStyles, options);
 		}
 		for(var i = 0; i < mayRemove.length; i++) {
@@ -81,21 +81,35 @@ function addStylesToDom(styles, options) {
 	}
 }
 
-function listToStyles(list) {
+function objectToStyles(object) {
 	var styles = [];
 	var newStyles = {};
-	for(var i = 0; i < list.length; i++) {
-		var item = list[i];
-		var id = item[0];
-		var css = item[1];
-		var media = item[2];
-		var sourceMap = item[3];
-		var part = {css: css, media: media, sourceMap: sourceMap};
-		if(!newStyles[id])
-			styles.push(newStyles[id] = {id: id, parts: [part]});
-		else
-			newStyles[id].parts.push(part);
+
+	styles.push(
+		newStyles[object.id] = { id: object.id, parts: [
+			{css: object.content, media: '', sourceMap: object.sourceMap}
+		] }
+	);
+
+	function recurse(parentObject) {
+		for (var i = 0; i < parentObject.mediaQueries.length; i++) {
+			var childObject = parentObject.mediaQueries[i][0];
+			var mediaQuery = parentObject.mediaQueries[i][1];
+			var id = childObject.id;
+			var css = childObject.content;
+			var sourceMap = childObject.sourceMap;
+			var part = {css: css, media: mediaQuery, sourceMap: sourceMap};
+			if(!newStyles[id]) {
+				styles.push(newStyles[id] = {id: id, parts: [part]});
+			} else {
+				newStyles[id].parts.push(part);
+				recurse(childObject);
+			}
+		}
 	}
+
+	recurse(object);
+
 	return styles;
 }
 

--- a/addStyles.js
+++ b/addStyles.js
@@ -91,24 +91,19 @@ function objectToStyles(object) {
 		] }
 	);
 
-	function recurse(parentObject) {
-		for (var i = 0; i < parentObject.mediaQueries.length; i++) {
-			var childObject = parentObject.mediaQueries[i][0];
-			var mediaQuery = parentObject.mediaQueries[i][1];
-			var id = childObject.id;
-			var css = childObject.content;
-			var sourceMap = childObject.sourceMap;
-			var part = {css: css, media: mediaQuery, sourceMap: sourceMap};
-			if(!newStyles[id]) {
-				styles.push(newStyles[id] = {id: id, parts: [part]});
-			} else {
-				newStyles[id].parts.push(part);
-				recurse(childObject);
-			}
+	for (var i = 0; i < object.imports.length; i++) {
+		var childObject = object.imports[i][0];
+		var mediaQuery = object.imports[i][1];
+		var id = childObject.id;
+		var css = childObject.content;
+		var sourceMap = childObject.sourceMap;
+		var part = {css: css, media: mediaQuery, sourceMap: sourceMap};
+		if(!newStyles[id]) {
+			styles.push(newStyles[id] = {id: id, parts: [part]});
+		} else {
+			newStyles[id].parts.push(part);
 		}
 	}
-
-	recurse(object);
 
 	return styles;
 }

--- a/index.js
+++ b/index.js
@@ -8,19 +8,31 @@ module.exports = function() {};
 module.exports.pitch = function(remainingRequest) {
 	if(this.cacheable) this.cacheable();
 	var query = loaderUtils.parseQuery(this.query);
+
+	var importJs;
+	var loaders = remainingRequest.split('!');
+	if (loaders[0].indexOf('/css-loader/index.js') != -1) {
+		importJs = "import { $cssLoader } from " + loaderUtils.stringifyRequest(this, "!!" + remainingRequest) + ";\n" +
+			"export * from " + loaderUtils.stringifyRequest(this, "!!" + remainingRequest) + ";\n" +
+			"export { default } from " + loaderUtils.stringifyRequest(this, "!!" + remainingRequest) + ";\n";
+	} else {
+		importJs = "var $cssLoader = {\n" +
+			"\t id: module.id,\n" + 
+			"\t content: require(" + loaderUtils.stringifyRequest(this, "!!" + remainingRequest) + "),\n" +
+			"\t mediaQueries: []\n" +
+			"};\n";
+	}
 	return [
 		"// style-loader: Adds some css to the DOM by adding a <style> tag",
 		"",
 		"// load the styles",
-		"var content = require(" + loaderUtils.stringifyRequest(this, "!!" + remainingRequest) + ");",
-		"if(typeof content === 'string') content = [[module.id, content, '']];",
+		importJs,
 		"// add the styles to the DOM",
-		"var update = require(" + loaderUtils.stringifyRequest(this, "!" + path.join(__dirname, "addStyles.js")) + ")(content, " + JSON.stringify(query) + ");",
-		"if(content.locals) module.exports = content.locals;",
+		"var update = require(" + loaderUtils.stringifyRequest(this, "!" + path.join(__dirname, "addStyles.js")) + ")($cssLoader, " + JSON.stringify(query) + ");",
 		"// Hot Module Replacement",
 		"if(module.hot) {",
 		"	// When the styles change, update the <style> tags",
-		"	if(!content.locals) {",
+		"	if(false/*!content.locals*/) {",
 		"		module.hot.accept(" + loaderUtils.stringifyRequest(this, "!!" + remainingRequest) + ", function() {",
 		"			var newContent = require(" + loaderUtils.stringifyRequest(this, "!!" + remainingRequest) + ");",
 		"			if(typeof newContent === 'string') newContent = [[module.id, newContent, '']];",

--- a/index.js
+++ b/index.js
@@ -12,11 +12,11 @@ module.exports.pitch = function(remainingRequest) {
 	var importJs;
 	var loaders = remainingRequest.split('!');
 	if (loaders[0].indexOf('/css-loader/index.js') != -1) {
-		importJs = "import { $cssLoader } from " + loaderUtils.stringifyRequest(this, "!!" + remainingRequest) + ";\n" +
+		importJs = "import { $css } from " + loaderUtils.stringifyRequest(this, "!!" + remainingRequest) + ";\n" +
 			"export * from " + loaderUtils.stringifyRequest(this, "!!" + remainingRequest) + ";\n" +
 			"export { default } from " + loaderUtils.stringifyRequest(this, "!!" + remainingRequest) + ";\n";
 	} else {
-		importJs = "var $cssLoader = {\n" +
+		importJs = "var $css = {\n" +
 			"\t id: module.id,\n" + 
 			"\t content: require(" + loaderUtils.stringifyRequest(this, "!!" + remainingRequest) + "),\n" +
 			"\t mediaQueries: []\n" +
@@ -24,15 +24,16 @@ module.exports.pitch = function(remainingRequest) {
 	}
 	return [
 		"// style-loader: Adds some css to the DOM by adding a <style> tag",
-		"",
+		// TODO: Update HMR
+		"var content = { locals: true };",
 		"// load the styles",
 		importJs,
 		"// add the styles to the DOM",
-		"var update = require(" + loaderUtils.stringifyRequest(this, "!" + path.join(__dirname, "addStyles.js")) + ")($cssLoader, " + JSON.stringify(query) + ");",
+		"var update = require(" + loaderUtils.stringifyRequest(this, "!" + path.join(__dirname, "addStyles.js")) + ")($css, " + JSON.stringify(query) + ");",
 		"// Hot Module Replacement",
 		"if(module.hot) {",
 		"	// When the styles change, update the <style> tags",
-		"	if(false/*!content.locals*/) {",
+		"	if(!content.locals) {",
 		"		module.hot.accept(" + loaderUtils.stringifyRequest(this, "!!" + remainingRequest) + ", function() {",
 		"			var newContent = require(" + loaderUtils.stringifyRequest(this, "!!" + remainingRequest) + ");",
 		"			if(typeof newContent === 'string') newContent = [[module.id, newContent, '']];",


### PR DESCRIPTION
This PR is incomplete (HMR not implemented, no tests), posting for any feedback on the approach taken.

**What kind of change does this PR introduce?**

Implements native ES6 imports and exports. Updated to consumes the output of this PR for css-loader: https://github.com/webpack/css-loader/pull/402 

**Did you add tests for your changes?**

Not yet

**If relevant, did you update the README?**

Not yet

**Summary**

Updating css-loader with ES6 exports and compatibility with tree shaking required a new export structure, so this version supports that.

**Does this PR introduce a breaking change?**

No, exported symbols should be the same.

**Other information**

Changed listToStyles to objectToStyles. css-loader exports a $cssLoader object which contains css source, sourcemap, id and a list of imported css files & media queries to recursively add to the styles list.