### PR TITLE
Fixed link to local scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ require("style-loader/url!file-loader!./file.css");
 
 (experimental)
 
-When using [local scope CSS](https://github.com/webpack/css-loader#local-scope) the module exports the generated identifiers:
+When using [local scope CSS](https://github.com/webpack/css-loader#css-scope) the module exports the generated identifiers:
 
 ``` javascript
 var style = require("style-loader!css-loader!./file.css");


### PR DESCRIPTION
Update the link to css-loader local scope

**What kind of change does this PR introduce?**
Updated README

**If relevant, did you update the README?**
Yes

**Summary**
The link to local scope seems to have been outdated, so this is a fix to the new hash.

**Does this PR introduce a breaking change?**
No
