### PR TITLE
Adds type attribute to the generated link element

### DIFF
--- a/addStyles.js
+++ b/addStyles.js
@@ -136,6 +136,7 @@ function createStyleElement(options) {
 function createLinkElement(options) {
 	var linkElement = document.createElement("link");
 	linkElement.rel = "stylesheet";
+	linkElement.type = "text/css";
 	insertStyleElement(options, linkElement);
 	return linkElement;
 }


### PR DESCRIPTION
Although the rel element is set to stylesheet the created link element does not specify the MIME type of the linked resource.
The MIME type is set to text/css similar to the case when an style element is created. This change also syncs with the addStylesUrl.js behavior where the type attribute is set.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
bugfix/enhancement

**Did you add tests for your changes?**
no

**If relevant, did you update the README?**
no

**Summary**
There are tools/frameworks that rely on MIME type for processing static content prior delivering the resources. In this particular case the href tag is not updated correctly because the type attribute is missing.
