### PR TITLE
Avoid source-map-loader matches incorrect source map url

### DIFF
--- a/addStyles.js
+++ b/addStyles.js
@@ -245,7 +245,7 @@ function updateLink(linkElement, obj) {
 
 	if(sourceMap) {
 		// http://stackoverflow.com/a/26603875
-		css += "\n/*# sourceMappingURL=data:application/json;base64," + btoa(unescape(encodeURIComponent(JSON.stringify(sourceMap)))) + " */";
+		css += "\n/*# sourceMapping" + "URL=data:application/json;base64," + btoa(unescape(encodeURIComponent(JSON.stringify(sourceMap)))) + " */";
 	}
 
 	var blob = new Blob([css], { type: "text/css" });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
bugfix

**Did you add tests for your changes?**
No. There is no test in the repository.

**If relevant, did you update the README?**
Not relevant.

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
There is a library bundled by webpack with style-loader. A consumer tries to load it through webpack with source-map-loader, but it fails to build.

The root cause is source-map-loader incorrectly thinks the string literal `"\n/*# sourceMappingURL=data:application/json;base64,"` is a directive for source map, it tries to find the source map here(while the actual source map directive is in the end of file), and fails.

This PR provide a workaround on the issue.

**Does this PR introduce a breaking change?**
No.

**Other information**
