### PR TITLE
fix: syntax error in IE10 and below because of `const` keyword

### DIFF
--- a/addStyles.js
+++ b/addStyles.js
@@ -249,7 +249,7 @@ function updateLink(linkElement, options, obj) {
 	on by default.  Otherwise default to the convertToAbsoluteUrls option
 	directly
 	*/
-	const autoFixUrls = options.convertToAbsoluteUrls === undefined && sourceMap;
+	var autoFixUrls = options.convertToAbsoluteUrls === undefined && sourceMap;
 
 	if (options.convertToAbsoluteUrls || autoFixUrls){
 		css = fixUrls(css);


### PR DESCRIPTION
**What kind of change does this PR introduce?**
a bugfix

**Did you add tests for your changes?**
no, but perhaps it can be fixed by introducing `eslint` to the project

**If relevant, did you update the README?**
no

**Summary**
`const` keyword was added in [this commit](https://github.com/webpack-contrib/style-loader/commit/19959eeb777bef4b1361501dc2ba2e4c785d63e0#diff-087146d437551cdc1e1ec8b9e39faaa3R252) and released as `0.14.0` which is causing syntax error in IE10 and below

**Does this PR introduce a breaking change?**
no
