### PR TITLE
Update for test for old IE versions

### DIFF
--- a/addStyles.js
+++ b/addStyles.js
@@ -16,7 +16,7 @@ var stylesInDom = {},
 		// Tests for existence of standard globals is to allow style-loader 
 		// to operate correctly into non-standard environments
 		// @see https://github.com/webpack-contrib/style-loader/issues/177
-        return window && document && document.all && !window.atob;
+		return window && document && document.all && !window.atob;
 	}),
 	getElement = (function(fn) {
 		var memo = {};

--- a/addStyles.js
+++ b/addStyles.js
@@ -11,7 +11,12 @@ var stylesInDom = {},
 		};
 	},
 	isOldIE = memoize(function() {
-		return /msie [6-9]\b/.test(self.navigator.userAgent.toLowerCase());
+		// Test for IE <= 9 as proposed by Browserhacks
+		// @see http://browserhacks.com/#hack-e71d8692f65334173fee715c222cb805
+		// Tests for existence of standard globals is to allow style-loader 
+		// to operate correctly into non-standard environments
+		// @see https://github.com/webpack-contrib/style-loader/issues/177
+        return window && document && document.all && !window.atob;
 	}),
 	getElement = (function(fn) {
 		var memo = {};


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bugfix for #177

**Did you add tests for your changes?**
Change is only testable in a browsers, code itself was tested using Browserstack into whole range of IE versions across all versions of Windows starting from XP and into outdated / actual versions of all browsers on Windows / OS X / Android / iOS / Windows Phone.

**If relevant, did you update the README?**
Doesn't seems to be relevant

**Summary**
Test for old IE versions is updated to avoid blind accessing properties of global objects that may not be available into certain real environments (examples are [here](https://github.com/webpack-contrib/style-loader/issues/177#issue-210376738) and [here](https://github.com/webpack-contrib/style-loader/issues/177#issuecomment-284250644)). Since the whole purpose of this test is about giving positive result for old IE versions (<=IE9) it can be safely updated with a [test](http://browserhacks.com/#hack-e71d8692f65334173fee715c222cb805) that is specifically targeted to these versions and doesn't tries to get deeper into (potentially missing) properties of globals.

**Does this PR introduce a breaking change?**
No