### PR TITLE
fix: bail early in a worker

### DIFF
--- a/addStyles.js
+++ b/addStyles.js
@@ -52,6 +52,11 @@ module.exports = function(list, options) {
 	// By default, add <style> tags to the bottom of the target
 	if (typeof options.insertAt === "undefined") options.insertAt = "bottom";
 
+	// Do not try to add a stylesheet in a worker context;
+	if (!self.document) {
+		return;
+	}
+
 	var styles = listToStyles(list);
 	addStylesToDom(styles, options);
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Fixes #203 

**Did you add tests for your changes?**
No, I'm not sure how to test the absence of `document` in jsdom.

**If relevant, did you update the README?**
no. This does not change behavior.

**Summary**

This makes it safe to require a modules in a worker context who might have a dependent file that require's a CSS file.  #203.

This is common in our app where our utils directory is mixed between UI component and business logic.

