### PR TITLE
docs(README): fix a typo in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ import style from './file.css'
 {
   test: /\.css$/,
   use: [
-    { loader: 'style-laoder', options: { attrs: { id: 'id' } } }
+    { loader: 'style-loader', options: { attrs: { id: 'id' } } }
     { loader: 'css-loader' }
   ]
 }


### PR DESCRIPTION
Fixed a typo in the example code
given in the readme
