### PR TITLE
docs(readme): Fix markdown error

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
       src="https://webpack.js.org/assets/icon-square-big.svg">
   </a>
   <h1>Style Loader</h1>
-  <p>Adds CSS to the DOM by injecting a `<style>` tag</p>
+  <p>Adds CSS to the DOM by injecting a `&lt;style&gt;` tag</p>
 </div>
 
 <h2 align="center">Install</h2>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
A docs bugfix.

**Did you add tests for your changes?**

N/A

**If relevant, did you update the README?**

Yes.

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
README contained unescaped & unclosed `<style>` tag that made almost the whole
README unreadable on the npm package page; see:
https://www.npmjs.com/package/style-loader

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**Other information**

This is a good test page to see how READMEs will display on npm:
https://revin.github.io/marky-markdown/
