### PR TITLE
docs(readme): Fix the `<style>` code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
       src="https://webpack.js.org/assets/icon-square-big.svg">
   </a>
   <h1>Style Loader</h1>
-  <p>Adds CSS to the DOM by injecting a `&lt;style&gt;` tag</p>
+  <p>Adds CSS to the DOM by injecting a <code>&lt;style&gt;</code> tag</p>
 </div>
 
 <h2 align="center">Install</h2>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

A docs bugfix.

**Did you add tests for your changes?**

N/A

**If relevant, did you update the README?**

Yes.

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
PR #227 made the README not broken completely on the npm package page (https://www.npmjs.com/package/style-loader) but didn't make the code block a real code block. Backticks are only used to delimit code blocks when used on the top level of the Markdown file; once they appear in an HTML block they're treated as regular symbols. The proper fix is to use the `<code>` tag.

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**Other information**
