### PR TITLE
fix: fallback for `document.querySelector`

### DIFF
--- a/addStyles.js
+++ b/addStyles.js
@@ -27,7 +27,9 @@ var stylesInDom = {},
 			return memo[selector]
 		};
 	})(function (styleTarget) {
-		return document.querySelector(styleTarget)
+		return document && document.querySelector
+			? document.querySelector(styleTarget)
+			: document.getElementsByTagName('head')[0];
 	}),
 	singletonElement = null,
 	singletonCounter = 0,

--- a/addStyles.js
+++ b/addStyles.js
@@ -27,7 +27,7 @@ var stylesInDom = {},
 			return memo[selector]
 		};
 	})(function (styleTarget) {
-		return document && document.querySelector
+		return document.querySelector
 			? document.querySelector(styleTarget)
 			: document.getElementsByTagName('head')[0];
 	}),


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bugfix. It's a fallback for older / non-standard devices, that do not support document.querySelector

**Did you add tests for your changes?**

No.

**If relevant, did you update the README?**

No.

**Summary**

Old / non-standard browsers would throw an error here. This fix will check if browser has querySelector and if it does not - fallback to putting styles to HEAD.

**Does this PR introduce a breaking change?**

No.

**Other information**

This fix is important for e.g. HbbTv and SmartTv applications, that supposed to run on old devices with limited resources (so, too many polyfills is not welcome).