### PR TITLE
fix(url): use `loaderUtils.stringifyRequest` to avoid invalidating hashes due to absolute paths

### DIFF
--- a/url.js
+++ b/url.js
@@ -18,7 +18,7 @@ module.exports.pitch = function (request) {
 
 	return [
 		"// style-loader: Adds some reference to a css file to the DOM by adding a <link> tag",
-		"var update = require(" + JSON.stringify("!" + path.join(__dirname, "lib", "addStyleUrl.js")) + ")(",
+		"var update = require(" + loaderUtils.stringifyRequest(this, "!" + path.join(__dirname, "lib", "addStyleUrl.js")) + ")(",
 		"\trequire(" + loaderUtils.stringifyRequest(this, "!!" + request) + ")",
 		", " + JSON.stringify(options) + ");",
 		"// Hot Module Replacement",


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bugfix

**Did you add tests for your changes?**

✅ 

**If relevant, did you update the README?**

✅ 

**Summary**

Fixes #241 

**Does this PR introduce a breaking change?**

No