### PR TITLE
fix: Adds null check to `removeStyleElement`

### DIFF
--- a/lib/addStyles.js
+++ b/lib/addStyles.js
@@ -170,7 +170,7 @@ function removeStyleElement (style) {
 	style.parentNode.removeChild(style);
 
 	var idx = stylesInsertedAtTop.indexOf(style);
-	if (idx >= 0) {
+	if(idx >= 0) {
 		stylesInsertedAtTop.splice(idx, 1);
 	}
 }

--- a/lib/addStyles.js
+++ b/lib/addStyles.js
@@ -166,11 +166,11 @@ function insertStyleElement (options, style) {
 }
 
 function removeStyleElement (style) {
+	if (style.parentNode === null) return false;
 	style.parentNode.removeChild(style);
 
 	var idx = stylesInsertedAtTop.indexOf(style);
-
-	if(idx >= 0) {
+	if (idx >= 0) {
 		stylesInsertedAtTop.splice(idx, 1);
 	}
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?**
bugfix

**Did you add tests for your changes?**
Private function… no tests.

**If relevant, did you update the README?**
Not relevant.

**Summary**
style-loader was choking on the CSS Modules `composes` feature and throwing a fatal error. Adding a check to the `removeStyleElement` function in `lib/addStyles.js` seems to solve the problem.

**Does this PR introduce a breaking change?**
No.

Closes #182