### PR TITLE
fix(addStyles): use `typeof` to check for existence of `window` && `document` objects

### DIFF
--- a/lib/addStyles.js
+++ b/lib/addStyles.js
@@ -20,7 +20,7 @@ var isOldIE = memoize(function () {
 	// Tests for existence of standard globals is to allow style-loader
 	// to operate correctly into non-standard environments
 	// @see https://github.com/webpack-contrib/style-loader/issues/177
-	return window && document && document.all && !window.atob;
+	return (typeof window !== "undefined") && (typeof document !== "undefined") && document.all && !window.atob;
 });
 
 var getElement = (function (fn) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Fixes the following error which occurs during Webpack build by adding the check via the `typeof` operator. 

```
        return window && document && document.all && !window.atob;
               ^

ReferenceError: window is not defined
    at C:\Users\ucadmin\Documents\uc\admin\build\server.js:32858:9
```

**Did you add tests for your changes?**
n/a

**If relevant, did you update the README?**
n/a

**Summary**

Of note, other places in this file use the `typeof` operator, but curiously it is not done here.


**Does this PR introduce a breaking change?**
No

**Other information**
n/a, it's a one-liner 😄 