### PR TITLE
feat: support 'before' insertions (`options.insertAt`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,8 +293,7 @@ A new `<style>` element can be inserted before a specific element by passing an 
   loader: 'style-loader'
   options: {
     insertAt: {
-        type: 'before',
-        selector: '#style-overrides'
+        before: '#style-overrides'
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ By default, the style-loader appends `<style>` elements to the end of the style 
 }
 ```
 
-A new `<style>` element can be inserted before a specific element by passing an object with `type='before'`, e.g.
+A new `<style>` element can be inserted before a specific element by passing an object, e.g.
 
 **webpack.config.js**
 ```js

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Styles are not added on `import/require()`, but instead on call to `use`/`ref`. 
 |**`transform`** |`{Function}`|`false`|Transform/Conditionally load CSS by passing a transform/condition function|
 |**`insertAt`**|`{String}`|`bottom`|Inserts `<style></style>` at the given position|
 |**`insertInto`**|`{String}`|`<head>`|Inserts `<style></style>` into the given position|
+|**`insertBefore`**|`{String}`|``|A query string specifying an element to insert new `<style>` before, required when `insertAt="before"`|
 |**`sourceMap`**|`{Boolean}`|`false`|Enable/Disable Sourcemaps|
 |**`convertToAbsoluteUrls`**|`{Boolean}`|`false`|Coverts relative URLs to absolute urls, when source maps are enabled|
 
@@ -281,6 +282,19 @@ By default, the style-loader appends `<style>` elements to the end of the style 
   loader: 'style-loader'
   options: {
     insertAt: 'top'
+  }
+}
+```
+
+A new `<style>` element can be inserted before a specific element using the `before` value
+
+**webpack.config.js**
+```js
+{
+  loader: 'style-loader'
+  options: {
+    insertAt: 'before',
+    insertBefore: '#style-overrides'
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Styles are not added on `import/require()`, but instead on call to `use`/`ref`. 
 |**`base`** |`{Number}`|`true`|Set module ID base (DLLPlugin)|
 |**`attrs`**|`{Object}`|`{}`|Add custom attrs to `<style></style>`|
 |**`transform`** |`{Function}`|`false`|Transform/Conditionally load CSS by passing a transform/condition function|
-|**`insertAt`**|`{String}`|`bottom`|Inserts `<style></style>` at the given position|
+|**`insertAt`**|`{String\|Object}`|`bottom`|Inserts `<style></style>` at the given position|
 |**`insertInto`**|`{String}`|`<head>`|Inserts `<style></style>` into the given position|
 |**`sourceMap`**|`{Boolean}`|`false`|Enable/Disable Sourcemaps|
 |**`convertToAbsoluteUrls`**|`{Boolean}`|`false`|Coverts relative URLs to absolute urls, when source maps are enabled|
@@ -293,7 +293,7 @@ A new `<style>` element can be inserted before a specific element by passing an 
   loader: 'style-loader'
   options: {
     insertAt: {
-        before: '#style-overrides'
+        before: '#id'
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -139,7 +139,6 @@ Styles are not added on `import/require()`, but instead on call to `use`/`ref`. 
 |**`transform`** |`{Function}`|`false`|Transform/Conditionally load CSS by passing a transform/condition function|
 |**`insertAt`**|`{String}`|`bottom`|Inserts `<style></style>` at the given position|
 |**`insertInto`**|`{String}`|`<head>`|Inserts `<style></style>` into the given position|
-|**`insertBefore`**|`{String}`|``|A query string specifying an element to insert new `<style>` before, required when `insertAt="before"`|
 |**`sourceMap`**|`{Boolean}`|`false`|Enable/Disable Sourcemaps|
 |**`convertToAbsoluteUrls`**|`{Boolean}`|`false`|Coverts relative URLs to absolute urls, when source maps are enabled|
 
@@ -286,15 +285,17 @@ By default, the style-loader appends `<style>` elements to the end of the style 
 }
 ```
 
-A new `<style>` element can be inserted before a specific element using the `before` value
+A new `<style>` element can be inserted before a specific element by passing an object with `type='before'`, e.g.
 
 **webpack.config.js**
 ```js
 {
   loader: 'style-loader'
   options: {
-    insertAt: 'before',
-    insertBefore: '#style-overrides'
+    insertAt: {
+        type: 'before',
+        selector: '#style-overrides'
+    }
   }
 }
 ```

--- a/lib/addStyles.js
+++ b/lib/addStyles.js
@@ -72,6 +72,8 @@ module.exports = function(list, options) {
 	// By default, add <style> tags to the bottom of the target
 	if (!options.insertAt) options.insertAt = "bottom";
 
+	if (options.insertAt === "before" && !options.insertBefore) throw new Error("Must specify selector in `insertBefore` when specifying `insertAt = 'before'`");
+
 	var styles = listToStyles(list, options);
 
 	addStylesToDom(styles, options);
@@ -170,6 +172,9 @@ function insertStyleElement (options, style) {
 		stylesInsertedAtTop.push(style);
 	} else if (options.insertAt === "bottom") {
 		target.appendChild(style);
+	} else if (options.insertAt === "before") {
+		var nextSibling = getElement(options.insertInto + " " + options.insertBefore);
+		target.insertBefore(style, nextSibling);
 	} else {
 		throw new Error("Invalid value for parameter 'insertAt'. Must be 'top' or 'bottom'.");
 	}

--- a/lib/addStyles.js
+++ b/lib/addStyles.js
@@ -72,8 +72,6 @@ module.exports = function(list, options) {
 	// By default, add <style> tags to the bottom of the target
 	if (!options.insertAt) options.insertAt = "bottom";
 
-	if (options.insertAt === "before" && !options.insertBefore) throw new Error("Must specify selector in `insertBefore` when specifying `insertAt = 'before'`");
-
 	var styles = listToStyles(list, options);
 
 	addStylesToDom(styles, options);
@@ -172,11 +170,11 @@ function insertStyleElement (options, style) {
 		stylesInsertedAtTop.push(style);
 	} else if (options.insertAt === "bottom") {
 		target.appendChild(style);
-	} else if (options.insertAt === "before") {
-		var nextSibling = getElement(options.insertInto + " " + options.insertBefore);
+	} else if (typeof options.insertAt === "object" && options.insertAt.type === "before") {
+		var nextSibling = getElement(options.insertInto + " " + options.insertAt.selector);
 		target.insertBefore(style, nextSibling);
 	} else {
-		throw new Error("[Style Loader]\n\n Invalid value for parameter 'insertAt' ('options.insertAt') found.\n Must be 'top', 'bottom', or 'before'.\n (https://github.com/webpack-contrib/style-loader#insertat)\n");
+		throw new Error("[Style Loader]\n\n Invalid value for parameter 'insertAt' ('options.insertAt') found.\n Must be 'top', 'bottom', or Object.\n (https://github.com/webpack-contrib/style-loader#insertat)\n");
 	}
 }
 

--- a/lib/addStyles.js
+++ b/lib/addStyles.js
@@ -176,7 +176,7 @@ function insertStyleElement (options, style) {
 		var nextSibling = getElement(options.insertInto + " " + options.insertBefore);
 		target.insertBefore(style, nextSibling);
 	} else {
-		throw new Error("Invalid value for parameter 'insertAt'. Must be 'top' or 'bottom'.");
+		throw new Error("[Style Loader]\n\n Invalid value for parameter 'insertAt' ('options.insertAt') found.\n Must be 'top', 'bottom', or 'before'.\n (https://github.com/webpack-contrib/style-loader#insertat)\n");
 	}
 }
 

--- a/lib/addStyles.js
+++ b/lib/addStyles.js
@@ -170,8 +170,8 @@ function insertStyleElement (options, style) {
 		stylesInsertedAtTop.push(style);
 	} else if (options.insertAt === "bottom") {
 		target.appendChild(style);
-	} else if (typeof options.insertAt === "object" && options.insertAt.type === "before") {
-		var nextSibling = getElement(options.insertInto + " " + options.insertAt.selector);
+	} else if (typeof options.insertAt === "object" && options.insertAt.before) {
+		var nextSibling = getElement(options.insertInto + " " + options.insertAt.before);
 		target.insertBefore(style, nextSibling);
 	} else {
 		throw new Error("[Style Loader]\n\n Invalid value for parameter 'insertAt' ('options.insertAt') found.\n Must be 'top', 'bottom', or Object.\n (https://github.com/webpack-contrib/style-loader#insertat)\n");

--- a/options.json
+++ b/options.json
@@ -9,7 +9,7 @@
       "type": "object"
     },
     "insertAt": {
-      "type": "string"
+      "type": ["string", "object"]
     },
     "insertInto": {
       "type": "string"

--- a/test/basicTest.js
+++ b/test/basicTest.js
@@ -96,8 +96,10 @@ describe("basic tests", function() {
   }); // it insert at top
 
   it("insert at before", function(done) {
-    styleLoaderOptions.insertAt = "before";
-    styleLoaderOptions.insertBefore = "#existing-style";
+    styleLoaderOptions.insertAt = {
+        type: "before",
+        selector: "#existing-style"
+    };
 
     let expected = [requiredStyle, existingStyle].join("");
 
@@ -105,8 +107,10 @@ describe("basic tests", function() {
   }); // it insert at before
 
   it("insert at before invalid selector", function(done) {
-    styleLoaderOptions.insertAt = "before";
-    styleLoaderOptions.insertBefore = "#missing";
+    styleLoaderOptions.insertAt = {
+        type: "before",
+        selector: "#missing"
+    };
 
     let expected = [existingStyle, requiredStyle].join("\n");
 

--- a/test/basicTest.js
+++ b/test/basicTest.js
@@ -19,7 +19,7 @@ describe("basic tests", function() {
       }
     `,
     requiredStyle = `<style type="text/css">${requiredCss}</style>`,
-    existingStyle = "<style>.existing { color: yellow }</style>",
+    existingStyle = `<style id="existing-style">.existing { color: yellow }</style>`,
     checkValue = '<div class="check">check</div>',
     rootDir = path.resolve(__dirname + "/../") + "/",
     jsdomHtml = [
@@ -94,6 +94,24 @@ describe("basic tests", function() {
 
     runCompilerTest(expected, done);
   }); // it insert at top
+
+  it("insert at before", function(done) {
+    styleLoaderOptions.insertAt = "before";
+    styleLoaderOptions.insertBefore = "#existing-style";
+
+    let expected = [requiredStyle, existingStyle].join("");
+
+    runCompilerTest(expected, done);
+  }); // it insert at before
+
+  it("insert at before invalid selector", function(done) {
+    styleLoaderOptions.insertAt = "before";
+    styleLoaderOptions.insertBefore = "#missing";
+
+    let expected = [existingStyle, requiredStyle].join("\n");
+
+    runCompilerTest(expected, done);
+  }); // it insert at before
 
   it("insert into", function(done) {
     let selector = "div.target";

--- a/test/basicTest.js
+++ b/test/basicTest.js
@@ -97,8 +97,7 @@ describe("basic tests", function() {
 
   it("insert at before", function(done) {
     styleLoaderOptions.insertAt = {
-        type: "before",
-        selector: "#existing-style"
+        before: "#existing-style"
     };
 
     let expected = [requiredStyle, existingStyle].join("");
@@ -108,8 +107,7 @@ describe("basic tests", function() {
 
   it("insert at before invalid selector", function(done) {
     styleLoaderOptions.insertAt = {
-        type: "before",
-        selector: "#missing"
+        before: "#missing"
     };
 
     let expected = [existingStyle, requiredStyle].join("\n");


### PR DESCRIPTION
Allow new styles to be inserted before other `<style>` or `<link>` elements that
exist on the page. This allows more precise ordering for complex style overrides
between multiple sources.

**What kind of change does this PR introduce?**
New feature

**Did you add tests for your changes?**
Yes

**If relevant, did you update the README?**
Yes

**Summary**

This is a new feature adding a third possible value for `insertAt`: `"before"`. A new option value `insertBefore` which contains query selector to select the element that the new styles should precede.

Complicated style situations where multiple `<style>` tags exist and must be inserted in specific order to allow style-overrides to work across sections require more precise placement than just `top` or `bottom`. This feature allows more precise selection of exactly where to insert a new `<style>` section relative to other existing sections.

**Does this PR introduce a breaking change?**
No
