### PR TITLE
docs(README): fix bash code highlight

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 <h2 align="center">Install</h2>
 
-```
+```bash
 npm install style-loader --save-dev
 ```
 


### PR DESCRIPTION
## Summary
Fix bash code example highlight.
Tests are not required.
Only README was updated.

## Screenshots
Code text will be more accurate and nice.

### Current:
![style-loader 2017-08-19 18-01-43](https://user-images.githubusercontent.com/223620/29487858-ac182040-8508-11e7-857c-bd9b69d5ba60.png)
---
### Will be:
![style-loader 2017-08-19 18-01-43](https://user-images.githubusercontent.com/223620/29487877-f100da58-8508-11e7-8aaa-6560d634c6ab.png)

