### PR TITLE
fixed missing commas in configuration examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ This could be used for non local development and production.
 **webpack.config.js**
 ```js
 {
-  loader: 'style-loader'
+  loader: 'style-loader',
   options: {
     hmr: false
   }
@@ -246,7 +246,7 @@ If the return value of the `transform` function is falsy, the css will not be lo
 **webpack.config.js**
 ```js
 {
-  loader: 'style-loader'
+  loader: 'style-loader',
   options: {
     transform: 'path/to/transform.js'
   }
@@ -268,7 +268,7 @@ module.exports = function (css) {
 **webpack.config.js**
 ```js
 {
-  loader: 'style-loader'
+  loader: 'style-loader',
   options: {
     transform: 'path/to/conditional.js'
   }
@@ -294,7 +294,7 @@ By default, the style-loader appends `<style>` elements to the end of the style 
 **webpack.config.js**
 ```js
 {
-  loader: 'style-loader'
+  loader: 'style-loader',
   options: {
     insertAt: 'top'
   }
@@ -306,7 +306,7 @@ A new `<style>` element can be inserted before a specific element by passing an 
 **webpack.config.js**
 ```js
 {
-  loader: 'style-loader'
+  loader: 'style-loader',
   options: {
     insertAt: {
         before: '#id'
@@ -322,7 +322,7 @@ You can also insert the styles into a [ShadowRoot](https://developer.mozilla.org
 **webpack.config.js**
 ```js
 {
-  loader: 'style-loader'
+  loader: 'style-loader',
   options: {
     insertInto: '#host::shadow>#root'
   }
@@ -338,7 +338,7 @@ If defined, the style-loader will reuse a single `<style>` element, instead of a
 **webpack.config.js**
 ```js
 {
-  loader: 'style-loader'
+  loader: 'style-loader',
   options: {
     singleton: true
   }
@@ -352,7 +352,7 @@ Enable/Disable source map loading
 **webpack.config.js**
 ```js
 {
-  loader: 'style-loader'
+  loader: 'style-loader',
   options: {
     sourceMap: true
   }
@@ -366,7 +366,7 @@ If convertToAbsoluteUrls and sourceMaps are both enabled, relative urls will be 
 **webpack.config.js**
 ```js
 {
-  loader: 'style-loader'
+  loader: 'style-loader',
   options: {
     sourceMap: true,
     convertToAbsoluteUrls: true


### PR DESCRIPTION
**What kind of change does this PR introduce?**
documentation improvement

**Did you add tests for your changes?**
n/a

**If relevant, did you update the README?**
yes

**Summary**
Several configuration examples were missing commas in object syntax.
Form mine (and hopefully others) peace of mind

**Does this PR introduce a breaking change?**
no

**Other information**
