### PR TITLE
feat: Parse default HMR option via npm environmental variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Styles are not added on `import/require()`, but instead on call to `use`/`ref`. 
 
 |Name|Type|Default|Description|
 |:--:|:--:|:-----:|:----------|
-|**`hmr`**|`{Boolean}`|`true`|Enable/disable Hot Module Replacement (HMR), if disabled no HMR Code will be added (good for non local development/production)|
+|**`hmr`**|`{Boolean}`|`true` for non-prod, `false` for prod|Enable/disable Hot Module Replacement (HMR), if disabled no HMR Code will be added. When in development, default value to be true, while in production, default to be false|
 |**`base`** |`{Number}`|`true`|Set module ID base (DLLPlugin)|
 |**`attrs`**|`{Object}`|`{}`|Add custom attrs to `<style></style>`|
 |**`transform`** |`{Function}`|`false`|Transform/Conditionally load CSS by passing a transform/condition function|
@@ -146,7 +146,11 @@ Styles are not added on `import/require()`, but instead on call to `use`/`ref`. 
 ### `hmr`
 
 Enable/disable Hot Module Replacement (HMR), if disabled no HMR Code will be added.
-This could be used for non local development and production.
+If no specific value provided, the default value will be determined by the npm script that invoked webpack:
+  * If invoked via `npm preblish/prepublishOnly`, considered for production distribution, default to false.
+  * if invoked via other npm scripts or non-npm scripts, considered non-prod, default to true.
+
+You can always Provide a specific value to override the defaults.
 
 **webpack.config.js**
 ```js

--- a/index.js
+++ b/index.js
@@ -8,6 +8,8 @@ var path = require("path");
 var loaderUtils = require("loader-utils");
 var validateOptions = require('schema-utils');
 
+var parseHmrOption = require('./lib/parseHmrOption');
+
 module.exports = function () {};
 
 module.exports.pitch = function (request) {
@@ -17,7 +19,7 @@ module.exports.pitch = function (request) {
 
 	validateOptions(require('./options.json'), options, 'Style Loader')
 
-	options.hmr = typeof options.hmr === 'undefined' ? true : options.hmr;
+	options.hmr = parseHmrOption(options.hmr);
 
 	var hmrCode = [
 		"// Hot Module Replacement",

--- a/lib/addStyleUrl.js
+++ b/lib/addStyleUrl.js
@@ -3,6 +3,8 @@
 	Author Tobias Koppers @sokra
 */
 
+var parseHmrOption = require('./parseHmrOption');
+
 function addAttrs (element, attrs) {
 	Object.keys(attrs).forEach(function (key) {
 		element.setAttribute(key, attrs[key]);
@@ -18,7 +20,7 @@ module.exports = function addStyleUrl (url, options) {
 
 	options.attrs = typeof options.attrs === "object" ? options.attrs : {};
 
-	options.hmr = typeof options.hmr === 'undefined' ? true : options.hmr;
+	options.hmr = parseHmrOption(options.hmr);
 
 	var link = document.createElement("link");
 

--- a/lib/parseHmrOption.js
+++ b/lib/parseHmrOption.js
@@ -1,0 +1,36 @@
+// Detects the life cycle of npm for determination of whether it's production distribution
+var NPM_PREPUBLISH_EVENT_REGEX = /^prepublish(Only)?$/gi;
+
+/**
+ * Parse `options.hmr` value depends on the following condition:
+ *   1. If `options.hmr` is a set value, return itself
+ *   2. If `options.hmr` is missing with value `undefined`, try to parse the npm command used to
+ *     invoke webpack via npm lifecycle event, to determine the default value:
+ *       a) If invoked via npm `prepublish` or `prepublishOnly`, this is production distribution and
+ *         default value for `options.hmr` to be false.
+ *       b) If invoked via other npm scripts or non-npm commands, assuming this is local or dev env,
+ *         default value for `options.hmr` to be true.
+ * @param {Boolean|undefined} hmr - The original `options.hmr`
+ * @returns {Boolean}
+ */
+module.exports = function(hmr) {
+  if (typeof hmr !== 'undefined') {
+    return hmr;
+  }
+
+  var npmLifeCycleEvent = '';
+  var isProductionDistribution = false;
+  NPM_PREPUBLISH_EVENT_REGEX.lastIndex = 0;
+
+  try {
+    npmLifeCycleEvent = process.env.npm_lifecycle_event.trim();
+  } catch (e) {
+    // Not able to get the env object, no-op
+  }
+
+  if (npmLifeCycleEvent && NPM_PREPUBLISH_EVENT_REGEX.test(npmLifeCycleEvent)) {
+    isProductionDistribution = true;
+  }
+
+  return !isProductionDistribution;
+};

--- a/test/parseHmrOptionTest.js
+++ b/test/parseHmrOptionTest.js
@@ -1,0 +1,54 @@
+// Node v4 requires "use strict" to allow block scoped let & const
+"use strict";
+
+var assert = require("assert");
+
+var parseHmrOption = require("../lib/parseHmrOption");
+
+describe("parseHmrOption tests", function () {
+
+  it("should output same hmr value if defined", function () {
+    assert.equal(parseHmrOption(true), true);
+    assert.equal(parseHmrOption(false), false);
+  });
+
+  it("should output the right values if undefined", function () {
+    assert.equal(parseHmrOption(), true);
+    assert.equal(parseHmrOption(undefined), true);
+
+    var originalEvent = process.env && process.env.npm_lifecycle_event;
+
+    process.env = process.env || {};
+
+    process.env.npm_lifecycle_event = '';
+    assert.equal(parseHmrOption(), true);
+
+    process.env.npm_lifecycle_event = 'prepublish';
+    assert.equal(parseHmrOption(), false);
+
+    process.env.npm_lifecycle_event = 'prepublishOnly';
+    assert.equal(parseHmrOption(), false);
+
+    process.env.npm_lifecycle_event = 'PREPUBLISH';
+    assert.equal(parseHmrOption(), false);
+
+    process.env.npm_lifecycle_event = 'PREPUBLISHONLY';
+    assert.equal(parseHmrOption(), false);
+
+    process.env.npm_lifecycle_event = 'dev';
+    assert.equal(parseHmrOption(), true);
+
+    process.env.npm_lifecycle_event = 'test';
+    assert.equal(parseHmrOption(), true);
+
+    process.env.npm_lifecycle_event = 'start';
+    assert.equal(parseHmrOption(), true);
+
+    process.env.npm_lifecycle_event = 'something';
+    assert.equal(parseHmrOption(), true);
+
+    if (originalEvent) {
+      process.env.npm_lifecycle_event = originalEvent;
+    }
+  });
+});

--- a/url.js
+++ b/url.js
@@ -7,6 +7,8 @@ var path = require('path');
 var loaderUtils = require('loader-utils');
 var validateOptions = require('schema-utils');
 
+var parseHmrOption = require('./lib/parseHmrOption');
+
 module.exports = function () {};
 
 module.exports.pitch = function (request) {
@@ -16,7 +18,7 @@ module.exports.pitch = function (request) {
 
 	validateOptions(require('./options.json'), options, 'Style Loader (URL)');
 
-	options.hmr = typeof options.hmr === 'undefined' ? true : options.hmr;
+	options.hmr = parseHmrOption(options.hmr);
 
 	var hmrCode = [
 		"// Hot Module Replacement",

--- a/useable.js
+++ b/useable.js
@@ -7,6 +7,8 @@ var path = require('path');
 var loaderUtils = require("loader-utils");
 var validateOptions = require('schema-utils');
 
+var parseHmrOption = require('./lib/parseHmrOption');
+
 module.exports = function () {};
 
 module.exports.pitch = function (request) {
@@ -16,7 +18,7 @@ module.exports.pitch = function (request) {
 
 	validateOptions(require('./options.json'), options, 'Style Loader (Useable)');
 
-	options.hmr = typeof options.hmr === 'undefined' ? true : options.hmr;
+	options.hmr = parseHmrOption(options.hmr);
 
 	var hmrCode = [
 		"// Hot Module Replacement",


### PR DESCRIPTION
This is to better address https://github.com/webpack-contrib/style-loader/issues/263

This will eliminate the dead code block for most of the packages that relying on `npm publish` to publish to npm repository.

Parse `options.hmr` value depends on the following condition:
  1. If `options.hmr` is a set value, return itself
  2. If `options.hmr` is missing with value `undefined`, try to parse the npm command used to
    invoke webpack via npm lifecycle event, to determine the default value:
      a) If invoked via npm `prepublish` or `prepublishOnly`, this is production distribution and
        default value for `options.hmr` to be false.
      b) If invoked via other npm scripts or non-npm commands, assuming this is local or dev env,
        default value for `options.hmr` to be true.