### PR TITLE
fix(addStyles): allow `window` && `document` to not exist (isOldIE)

### DIFF
--- a/lib/addStyles.js
+++ b/lib/addStyles.js
@@ -20,7 +20,7 @@ var isOldIE = memoize(function () {
 	// Tests for existence of standard globals is to allow style-loader
 	// to operate correctly into non-standard environments
 	// @see https://github.com/webpack-contrib/style-loader/issues/177
-	return window && document && document.all && !window.atob;
+	return typeof window !== "undefined" && typeof document !== "undefined" && document.all && !window.atob;
 });
 
 var getElement = (function (fn) {


### PR DESCRIPTION
Fixes #272.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Bugfix

**Did you add tests for your changes?**
No. Do you test this type of behavior?

**Summary**
Uses `typeof` checks so the function doesn't crash if `window` or `document` don't exist.

**Does this PR introduce a breaking change?**
No.