### PR TITLE
fix(addStyles): correctly check `singleton` behavior when `{Boolean}` (`options.singleton`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Styles are not added on `import/require()`, but instead on call to `use`/`ref`. 
 |**`transform`** |`{Function}`|`false`|Transform/Conditionally load CSS by passing a transform/condition function|
 |**`insertAt`**|`{String\|Object}`|`bottom`|Inserts `<style></style>` at the given position|
 |**`insertInto`**|`{String}`|`<head>`|Inserts `<style></style>` into the given position|
+|**`singleton`**|`{Boolean}`|`undefined`|Reuses a single `<style></style>` element, instead of adding/removing individual elements for each required module.|
 |**`sourceMap`**|`{Boolean}`|`false`|Enable/Disable Sourcemaps|
 |**`convertToAbsoluteUrls`**|`{Boolean}`|`false`|Converts relative URLs to absolute urls, when source maps are enabled|
 
@@ -331,7 +332,7 @@ You can also insert the styles into a [ShadowRoot](https://developer.mozilla.org
 
 ### `singleton`
 
-If defined, the style-loader will reuse a single `<style>` element, instead of adding/removing individual elements for each required module.
+If defined, the style-loader will reuse a single `<style></style>` element, instead of adding/removing individual elements for each required module.
 
 > ℹ️  This option is on by default in IE9, which has strict limitations on the number of style tags allowed on a page. You can enable or disable it with the singleton option.
 

--- a/lib/addStyles.js
+++ b/lib/addStyles.js
@@ -64,7 +64,7 @@ module.exports = function(list, options) {
 
 	// Force single-tag solution on IE6-9, which has a hard limit on the # of <style>
 	// tags it will allow on a page
-	if (!options.singleton) options.singleton = isOldIE();
+	if (!options.singleton && typeof options.singleton !== "boolean") options.singleton = isOldIE();
 
 	// By default, add <style> tags to the <head> element
 	if (!options.insertInto) options.insertInto = "head";

--- a/test/basicTest.js
+++ b/test/basicTest.js
@@ -140,7 +140,7 @@ describe("basic tests", function() {
     }, selector);
   }); // it insert into
 
-  it("singleton", function(done) {
+  it("singleton (true)", function(done) {
     // Setup
     styleLoaderOptions.singleton = true;
 
@@ -156,6 +156,27 @@ describe("basic tests", function() {
     let expected = [
       existingStyle,
       `<style type="text/css">${requiredCss}${requiredCssTwo}</style>`
+    ].join("\n");
+
+    runCompilerTest(expected, done);
+  }); // it singleton
+
+  it("singleton (false)", function(done) {
+    // Setup
+    styleLoaderOptions.singleton = false;
+
+    fs.writeFileSync(
+      rootDir + "main.js",
+      [
+        "var a = require('./style.css');",
+        "var b = require('./styleTwo.css');"
+      ].join("\n")
+    );
+
+    // Run
+    let expected = [
+      existingStyle,
+      `<style type="text/css">${requiredCss}</style><style type="text/css">${requiredCssTwo}</style>`
     ].join("\n");
 
     runCompilerTest(expected, done);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

bugfix

**Did you add tests for your changes?**

yes

**If relevant, did you update the README?**

yes, we don't have `singleton` option in table options, i don't know how it is happens

**Summary**

When `singleton: true` - i want to use one `style` tag.
When `singleton: false` - i want to use multiple `style` tags.
When `singleton` not specify (i.e. `undefined`) - i want the loader himself decide to use single or multiple `style` tags.

Issue: https://github.com/webpack-contrib/style-loader/issues/283

**Does this PR introduce a breaking change?**

No

**Other information**
