### PR TITLE
fix(addStyle): check if HTMLIFrameElement exist (not the case for cob…

### DIFF
--- a/lib/addStyles.js
+++ b/lib/addStyles.js
@@ -30,7 +30,7 @@ var getElement = (function (fn) {
 		if (typeof memo[selector] === "undefined") {
 			var styleTarget = fn.call(this, selector);
 			// Special case to return head of iframe instead of iframe itself
-			if (styleTarget instanceof window.HTMLIFrameElement) {
+			if (window.HTMLIFrameElement && styleTarget instanceof window.HTMLIFrameElement) {
 				try {
 					// This will throw an exception if access to iframe is blocked
 					// due to cross-origin restrictions


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Fix on some browser the fact that `window.HTMLIFrameElement` doesn't exist

**Did you add tests for your changes?**

Not relevant IHMO

**If relevant, did you update the README?**

Not relevant IHMO

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Style-loader can be used with Cobalt browser (https://cobalt.foo)

**Does this PR introduce a breaking change?**

No

**Other information**

Thank for your work
