### PR TITLE
Don't cancel whole HMR pass in case local idents has changed

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,10 +55,10 @@ module.exports.pitch = function (request) {
 		"			return idx === 0;",
 		"		}(content.locals, newContent.locals));",
 		"",
-		// This error is caught and not shown and causes a full reload
-		"		if(!locals) throw new Error('Aborting CSS HMR due to changed css-modules locals.');",
-		"",
 		"		update(newContent);",
+		// 	Pass hot reload further up to dependency tree in case locals has changed
+		"		if(!locals) return false",
+		"",
 		"	});",
 		"",
 		// When the module is disposed, remove the <style> tags


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
Bugfix
**Did you add tests for your changes?**
No, is a tiny one
**If relevant, did you update the README?**

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Currently in webpack css modules setup with HMR plugin forces full page reload if one of file local idents has changed. Instead of this, i'd let HMR go up to higher-level dependencies making them updating as well.

<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
Nope
**Other information**
