### PR TITLE
feat: enable tag type configuration

### DIFF
--- a/lib/addStyles.js
+++ b/lib/addStyles.js
@@ -201,7 +201,9 @@ function removeStyleElement (style) {
 function createStyleElement (options) {
 	var style = document.createElement("style");
 
-	options.attrs.type = "text/css";
+	if(options.attrs.type === undefined) {
+		options.attrs.type = "text/css";
+	}
 
 	addAttrs(style, options.attrs);
 	insertStyleElement(options, style);
@@ -212,7 +214,9 @@ function createStyleElement (options) {
 function createLinkElement (options) {
 	var link = document.createElement("link");
 
-	options.attrs.type = "text/css";
+	if(options.attrs.type === undefined) {
+		options.attrs.type = "text/css";
+	}
 	options.attrs.rel = "stylesheet";
 
 	addAttrs(link, options.attrs);

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -220,6 +220,26 @@ describe("basic tests", function() {
     runCompilerTest(expected, done);
   }); // it attrs
 
+  it("type attribute", function(done) {
+    // Setup
+    styleLoaderOptions.attrs = {type: 'text/less'};
+
+    fs.writeFileSync(
+      rootDir + "main.js",
+      [
+        "var a = require('./style.css');"
+      ].join("\n")
+    );
+
+    // Run
+    let expected = [
+      existingStyle,
+      `<style type="${styleLoaderOptions.attrs.type}">${requiredCss}</style>`
+    ].join("\n");
+
+    runCompilerTest(expected, done);
+  }); // it type attribute
+
   it("url", function(done) {
     cssRule.use = [
       {
@@ -260,6 +280,28 @@ describe("basic tests", function() {
 
     runCompilerTest(expected, done);
   }); // it url with attrs
+
+  it("url with type attribute", function (done) {
+    cssRule.use = [
+      {
+        loader: "style-loader/url",
+        options: {
+          attrs: {
+            type: 'text/less'
+          }
+        }
+      },
+      "file-loader"
+    ];
+
+    // Run
+    let expected = [
+      existingStyle,
+      '<link rel="stylesheet" type="text/less" href="ec9d4f4f24028c3d51bf1e7728e632ff.css">'
+    ].join("\n");
+
+    runCompilerTest(expected, done);
+  }); // it url with type attribute
 
   it("useable", function(done) {
     cssRule.use = [


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
**What kind of change does this PR introduce?**
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
Small feature

**Did you add tests for your changes?**
Yes.

**If relevant, did you update the README?**
No.

**Summary**
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
This lets projects using style-loader define the type of the style or link tags in the `attrs` option of the loader, along with other tag attributes. See [style-loader/issues/315](https://github.com/webpack-contrib/style-loader/issues/315)

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No.

**Other information**
