### PR TITLE
feat(addStyles): add support for `__webpack_nonce__`

### DIFF
--- a/lib/addStyles.js
+++ b/lib/addStyles.js
@@ -205,6 +205,13 @@ function createStyleElement (options) {
 		options.attrs.type = "text/css";
 	}
 
+	if(options.attrs.nonce === undefined) {
+		const nonce = getNonce();
+		if (nonce) {
+			options.attrs.nonce = nonce;
+		}
+	}
+
 	addAttrs(style, options.attrs);
 	insertStyleElement(options, style);
 
@@ -229,6 +236,14 @@ function addAttrs (el, attrs) {
 	Object.keys(attrs).forEach(function (key) {
 		el.setAttribute(key, attrs[key]);
 	});
+}
+
+function getNonce() {
+	if (typeof __webpack_nonce__ === 'undefined') {
+		return null;
+	}
+
+	return __webpack_nonce__;
 }
 
 function addStyle (obj, options) {

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -220,6 +220,27 @@ describe("basic tests", function() {
     runCompilerTest(expected, done);
   }); // it attrs
 
+  it("nonce", function(done) {
+    // Setup
+    const expectedNonce = "testNonce";
+
+    fs.writeFileSync(
+      rootDir + "main.js",
+      [
+        `__webpack_nonce__ = '${expectedNonce}'`,
+        "var a = require('./style.css');"
+      ].join("\n")
+    );
+
+    // Run
+    let expected = [
+      existingStyle,
+      `<style type="text/css" nonce="${expectedNonce}">${requiredCss}</style>`
+    ].join("\n");
+
+    runCompilerTest(expected, done);
+  }); // it attrs
+
   it("type attribute", function(done) {
     // Setup
     styleLoaderOptions.attrs = {type: 'text/less'};


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Feature to support `__webpack_nonce__` 

**Did you add tests for your changes?**
Yes, I added a test that verifies the nonce gets set on style tags. (Nonces will not help `link` tags as nonces are only used to allow inline styles.)

**If relevant, did you update the README?**
I wasn't sure where in the README I should put a note about supporting `__webpack_nonce__`, so I have omitted it for now. I can add it in if requested.

**Summary**
Currently if a site has a strict CSP that disallows `unsafe-inline` the rendered style tags from this loader will be ignored. Webpack supports adding a nonce via the `__webpack_nonce__` property. This change looks for that property and adds the nonce attribute to generated style tags.

More info here: #306 

**Does this PR introduce a breaking change?**
This is only breaking if the package consumer was expecting the styles not to load, so it should not be an issue. If the consumer was already adding a nonce attribute via the options object, then that will take precedence over the `__webpack_nonce__` property, so it shouldn't break anyone doing it that way.
