### PR TITLE
fix(index): make HMR try to work when locals changed

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,10 +55,12 @@ module.exports.pitch = function (request) {
 		"			return idx === 0;",
 		"		}(content.locals, newContent.locals));",
 		"",
-		// This error is caught and not shown and causes a full reload
-		"		if(!locals) throw new Error('Aborting CSS HMR due to changed css-modules locals.');",
+		"		if(!locals) console.warn('CSS-Modules locals changed. A full reload may be required.');",
 		"",
 		"		update(newContent);",
+		"",
+		"		module.exports = newContent.locals;",
+		"",
 		"	});",
 		"",
 		// When the module is disposed, remove the <style> tags


### PR DESCRIPTION
**What kind of change does this PR introduce?**
fix/improvement

**Did you add tests for your changes?**
No test case. Tested in a demo project.

**If relevant, did you update the README?**
Not relevant.

**Summary**
Enhance https://github.com/webpack-contrib/css-loader/issues/669 
If project use React, etc. for DOM render and handled JS HMR, all CSS module update can work without full reload

**Does this PR introduce a breaking change?**
NO

**Other information**
