### PR TITLE
fix(addStyles): use `var` instead of `const` (IE fix)

### DIFF
--- a/lib/addStyles.js
+++ b/lib/addStyles.js
@@ -209,7 +209,7 @@ function createStyleElement (options) {
 	}
 
 	if(options.attrs.nonce === undefined) {
-		const nonce = getNonce();
+		var nonce = getNonce();
 		if (nonce) {
 			options.attrs.nonce = nonce;
 		}


### PR DESCRIPTION
**What kind of change does this PR introduce?**

v0.22.0 introduced support for webpack nonces, however the code contains a `const` keyword which throws on IE10 and below. This PR replaces `const` with `var` so everybody's happy. I've verified this fix in IE10.
