### PR TITLE
feat(useable): add `insertInto` support (`options.insertInto`)

### DIFF
--- a/test/useable.test.js
+++ b/test/useable.test.js
@@ -48,11 +48,11 @@ describe("useable tests", function () {
       requiredCssTwo = ".requiredTwo { color: cyan }",
       localScopedCss = ":local(.className) { background: red; }",
       localComposingCss = `
-      :local(.composingClass) {
-        composes: className from './localScoped.css';
-        color: blue;
-      }
-    `,
+        :local(.composingClass) {
+          composes: className from './localScoped.css';
+          color: blue;
+        }
+      `,
       requiredStyle = `<style type="text/css">${requiredCss}</style>`,
       existingStyle = `<style id="existing-style">.existing { color: yellow }</style>`,
       checkValue = '<div class="check">check</div>',

--- a/test/useable.test.js
+++ b/test/useable.test.js
@@ -8,30 +8,136 @@ var loaderUtils = require('loader-utils');
 var useable = require("../useable");
 
 describe("useable tests", function () {
-  var sandbox = sinon.sandbox.create();
-  var getOptions;
+  describe('hmr', function () {
+    var sandbox = sinon.sandbox.create();
+    var getOptions;
 
-  beforeEach(() => {
-    // Mock loaderUtils to override options
-    getOptions = sandbox.stub(loaderUtils, 'getOptions');
+    beforeEach(() => {
+      // Mock loaderUtils to override options
+      getOptions = sandbox.stub(loaderUtils, 'getOptions');
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it("should output HMR code by default", function () {
+      assert.equal(/(module\.hot)/g.test(useable.pitch()), true);
+    });
+
+    it("should NOT output HMR code when options.hmr is false", function () {
+      getOptions.returns({hmr: false});
+      assert.equal(/(module\.hot)/g.test(useable.pitch()), false);
+    });
+
+    it("should output HMR code when options.hmr is true", function () {
+      getOptions.returns({hmr: true});
+      assert.equal(/(module\.hot)/g.test(useable.pitch()), true);
+    });
   });
 
-  afterEach(() => {
-    sandbox.restore();
-  });
+  describe('insert into', function () {
+    var path = require("path");
 
-  it("should output HMR code by default", function () {
-    assert.equal(/(module\.hot)/g.test(useable.pitch()), true);
-  });
+    var utils = require("./utils"),
+      runCompilerTest = utils.runCompilerTest;
 
-  it("should NOT output HMR code when options.hmr is false", function () {
-    getOptions.returns({hmr: false});
-    assert.equal(/(module\.hot)/g.test(useable.pitch()), false);
-  });
+    var fs;
 
-  it("should output HMR code when options.hmr is true", function () {
-    getOptions.returns({hmr: true});
-    assert.equal(/(module\.hot)/g.test(useable.pitch()), true);
+    var requiredCss = ".required { color: blue }",
+      requiredCssTwo = ".requiredTwo { color: cyan }",
+      localScopedCss = ":local(.className) { background: red; }",
+      localComposingCss = `
+      :local(.composingClass) {
+        composes: className from './localScoped.css';
+        color: blue;
+      }
+    `,
+      requiredStyle = `<style type="text/css">${requiredCss}</style>`,
+      existingStyle = `<style id="existing-style">.existing { color: yellow }</style>`,
+      checkValue = '<div class="check">check</div>',
+      rootDir = path.resolve(__dirname + "/../") + "/",
+      jsdomHtml = [
+        "<html>",
+        "<head id='head'>",
+        existingStyle,
+        "</head>",
+        "<body>",
+        "<div class='target'>",
+        checkValue,
+        "</div>",
+        "<iframe class='iframeTarget'/>",
+        "</body>",
+        "</html>"
+      ].join("\n"),
+      requiredJS = [
+        "var el = document.createElement('div');",
+        "el.id = \"test-shadow\";",
+        "document.body.appendChild(el)",
+        "var css = require('./style.css');",
+        "css.use();",
+      ].join("\n");
+
+    var styleLoaderOptions = {};
+    var cssRule = {};
+
+    var defaultCssRule = {
+      test: /\.css?$/,
+      use: [
+        {
+          loader: "style-loader/useable",
+          options: styleLoaderOptions
+        },
+        "css-loader"
+      ]
+    };
+
+    var webpackConfig = {
+      entry: "./main.js",
+      output: {
+        filename: "bundle.js"
+      },
+      module: {
+        rules: [cssRule]
+      }
+    };
+
+    var setupWebpackConfig = function() {
+      fs = utils.setup(webpackConfig, jsdomHtml);
+
+      // Create a tiny file system. rootDir is used because loaders are referring to absolute paths.
+      fs.mkdirpSync(rootDir);
+      fs.writeFileSync(rootDir + "main.js", requiredJS);
+      fs.writeFileSync(rootDir + "style.css", requiredCss);
+      fs.writeFileSync(rootDir + "styleTwo.css", requiredCssTwo);
+      fs.writeFileSync(rootDir + "localScoped.css", localScopedCss);
+      fs.writeFileSync(rootDir + "localComposing.css", localComposingCss);
+    };
+
+    beforeEach(function() {
+      // Reset all style-loader options
+      for (var member in styleLoaderOptions) {
+        delete styleLoaderOptions[member];
+      }
+
+      for (var member in defaultCssRule) {
+        cssRule[member] = defaultCssRule[member];
+      }
+
+      setupWebpackConfig();
+    }); // before each
+
+    it("insert into iframe", function(done) {
+      let selector = "iframe.iframeTarget";
+      styleLoaderOptions.insertInto = selector;
+
+      let expected = requiredStyle;
+
+      runCompilerTest(expected, done, function() {
+        return this.document.querySelector(selector).contentDocument.head.innerHTML;
+      }, selector);
+    }); // it insert into
+
   });
 
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
feature. adds support for insertInto with `useable`. fixes #327 

**Did you add tests for your changes?**
Yes

**If relevant, did you update the README?**
I didn't, I figured this feature should be assumed to work with `useable` as well. I can add documentation to point it out though.

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
This feature is needed for injecting styles into the iframe with `useable` AFTER the page has loaded. Having the ability to call `style.use()` when the iframe is being setup is crucial. In this scenario we can't use the basic style-loader because specifying the insertInto option will attempt to look for the iframe when it doesn't exist yet.

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No

**Other information**
n/a
