### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 npm install style-loader --save-dev
 ```
 
-<h2 align="center"><a href="https://webpack.js.org/concepts/loaders">Usage</a></h2>
+<h2 align="center">Usage</h2>
 
 It's recommended to combine `style-loader` with the [`css-loader`](https://github.com/webpack/css-loader)
 


### PR DESCRIPTION
Usage section was rendering as 'Usage Usage" class="icon-link" href="#usage">', removed the link, to make it consistent with source and rendering for css-loader for example.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Documentation bug fix

**Did you add tests for your changes?**
No

**If relevant, did you update the README?**
Yes, because the fix is to the README.md file.

**Summary**
Make the nice webpack documentation even better.

**Does this PR introduce a breaking change?**
I don't think so.

**Other information**
