### PR TITLE
Make HMR work when locals are changed, but with test repo to view it

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Styles are not added on `import/require()`, but instead on call to `use`/`ref`. 
 |**`singleton`**|`{Boolean}`|`undefined`|Reuses a single `<style></style>` element, instead of adding/removing individual elements for each required module.|
 |**`sourceMap`**|`{Boolean}`|`false`|Enable/Disable Sourcemaps|
 |**`convertToAbsoluteUrls`**|`{Boolean}`|`false`|Converts relative URLs to absolute urls, when source maps are enabled|
+|**`manualReload`**|`{Boolean}`|`false`|Enable/Disable automatic full reload|
 
 ### `hmr`
 

--- a/README.md
+++ b/README.md
@@ -391,6 +391,20 @@ If convertToAbsoluteUrls and sourceMaps are both enabled, relative urls will be 
 }
 ```
 
+### `manualReload`
+
+[PR#298](https://github.com/webpack/style-loader/pull/298) introduced behavior for an automatic full reload if css-modules locals were changed by silently handling throwing an error. This works for most situations, but in certain situations - e.g. using webpack-dev-middleware directly in Express.js for remote/non-same host development, the thrown error will crash the loader. If manualReload is enabled, an error is not thrown and instead the console warns that css-modules locals has been changed. This restores the behavior to prior the introduction of PR#298 and resolves [this issue](https://github.com/webpack/style-loader/issues/320) where style-loader was aborting.
+
+**webpack.config.js**
+```js
+{
+  loader: 'style-loader',
+  options: {
+    manualReload: true
+  }
+}
+```
+
 <h2 align="center">Maintainers</h2>
 
 <table>

--- a/README.md
+++ b/README.md
@@ -393,7 +393,7 @@ If convertToAbsoluteUrls and sourceMaps are both enabled, relative urls will be 
 
 ### `manualReload`
 
-[PR#298](https://github.com/webpack/style-loader/pull/298) introduced behavior for an automatic full reload if css-modules locals were changed by silently handling throwing an error. This works for most situations, but in certain situations - e.g. using webpack-dev-middleware directly in Express.js for remote/non-same host development, the thrown error will crash the loader. If manualReload is enabled, an error is not thrown and instead the console warns that css-modules locals has been changed. This restores the behavior to prior the introduction of PR#298 and resolves [this issue](https://github.com/webpack/style-loader/issues/320) where style-loader was aborting.
+[PR#298](https://github.com/webpack/style-loader/pull/298) introduced behavior for an automatic full reload if css-modules locals were changed by silently handling throwing an error. This works for most situations, but this change crashes the loader in certain situations - e.g. using webpack-hot-middleware and webpack-dev-middleware directly in Express.js for remote/non-same host development. If manualReload is enabled, an error is not thrown and instead the console warns that css-modules locals has been changed. This restores the behavior to prior the introduction of PR#298 and resolves [this issue](https://github.com/webpack/style-loader/issues/320) where style-loader was aborting.
 
 **webpack.config.js**
 ```js

--- a/index.js
+++ b/index.js
@@ -65,6 +65,12 @@ module.exports.pitch = function (request) {
 		: "		if(!locals) throw new Error('Aborting CSS HMR due to changed css-modules locals.');",
 		"",
 		"		update(newContent);",
+		"",
+		// Export the locals for the newContent otherwise a full reload will be
+		// necessary. We are not worried about any conflicts since the above 
+		// function asserts that newContent.locals will be a strict superset to
+		// content.locals.
+		"		module.exports = newContent.locals;",
 		"	});",
 		"",
 		// When the module is disposed, remove the <style> tags

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ module.exports.pitch = function (request) {
 	validateOptions(require('./options.json'), options, 'Style Loader')
 
 	options.hmr = typeof options.hmr === 'undefined' ? true : options.hmr;
+	options.manualReload = typeof options.manualReload === 'undefined' ? false : options.manualReload;
 
 	// The variable is needed, because the function should be inlined.
 	// If is just stored it in options, JSON.stringify will quote
@@ -55,8 +56,13 @@ module.exports.pitch = function (request) {
 		"			return idx === 0;",
 		"		}(content.locals, newContent.locals));",
 		"",
-		// This error is caught and not shown and causes a full reload
-		"		if(!locals) throw new Error('Aborting CSS HMR due to changed css-modules locals.');",
+		// Changing CSS locals should require a full reload under most conditions.
+		// Throwing an error will be silently caught and cause a full reload.
+		// In the cases were an automatic full reload is not wanted, e.g.
+		// the error is not silent caught, warn that the locals were changed.
+		(options.manualReload)
+		? "		if(!locals) console.warn('CSS-modules locals were changed. Full-reload may be required.');"
+		: "		if(!locals) throw new Error('Aborting CSS HMR due to changed css-modules locals.');",
 		"",
 		"		update(newContent);",
 		"	});",

--- a/options.json
+++ b/options.json
@@ -31,6 +31,9 @@
     },
     "convertToAbsoluteUrls": {
       "type": "boolean"
+    },
+    "manualReload": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Bugfix for https://github.com/webpack/style-loader/issues/320

**Did you add tests for your changes?**
No. There is not a direct way to test this change due to the many moving parts.

I created a repo at https://github.com/KevinCChan/css-hmr-bugfix to demo the change. All it does is open run a webserver on 127.0.0.1:8080 with a colored box to demo prefix and postfix behavior.

**If relevant, did you update the README?**
Yes

**Summary**
This is a bug fix for the crashing behavior introduced by https://github.com/webpack-contrib/style-loader/pull/298. There was a similar pull request, and we came to the same conclusion. I am doing my part and creating a test repository to acceptance test the changes so the fix can be integrated. I updated documentation as well.

**Does this PR introduce a breaking change?**
No, I made this a toggle option specifically to avoid introducing a breaking change.

**Other information**
Please reach to me if there are any issues!