### PR TITLE
Fixed `Useable` section code in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ By convention the `Reference Counter API` should be bound to `.useable.css` and 
     rules: [
       {
         test: /\.css$/,
+        exclude: /\.useable\.css$/,
         use: [
           { loader: "style-loader" },
           { loader: "css-loader" },


### PR DESCRIPTION
The code example does not include a `exclude` entry, which causes the loaders to load twice on ".useable.css" files and failing the build.