### PR TITLE
hoist schema require, less work when empty options or hmr === false

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,9 @@ var path = require("path");
 
 var loaderUtils = require("loader-utils");
 var validateOptions = require('schema-utils');
-var schema = require('./options.json')
+var schema = require('./options.json');
+
+var addStylesPath = path.join(__dirname, "lib", "addStyles.js");
 
 module.exports = function () {};
 
@@ -21,16 +23,17 @@ module.exports.pitch = function (request) {
 	var insertInto;
 
   if (options) {
-    validateOptions(schema, options, 'Style Loader');
+    validateOptions(schema, options, 'Style Loader (Useable)');
     options.hmr = typeof options.hmr === 'undefined' ? true : options.hmr;
 
-    if (typeof options.insertInto === "function") {
+    var insertIntoType = typeof options.insertInto;
+    if (insertIntoType === "function") {
       insertInto = options.insertInto.toString();
     }
 
     // We need to check if it a string, or variable will be "undefined"
     // and the loader crashes
-    if (typeof options.insertInto === "string") {
+    else if (insertIntoType === "string") {
       insertInto = '"' + options.insertInto + '"';
     }
   } else {
@@ -91,7 +94,7 @@ module.exports.pitch = function (request) {
 		"options.insertInto = " + insertInto + ";",
 		"",
 		// Add styles to the DOM
-		"var update = require(" + loaderUtils.stringifyRequest(this, "!" + path.join(__dirname, "lib", "addStyles.js")) + ")(content, options);",
+		"var update = require(" + loaderUtils.stringifyRequest(this, "!" + addStylesPath) + ")(content, options);",
 		"",
 		"if(content.locals) module.exports = content.locals;",
 		"",

--- a/index.js
+++ b/index.js
@@ -14,30 +14,30 @@ module.exports.pitch = function (request) {
 	if (this.cacheable) this.cacheable();
 
   var options = loaderUtils.getOptions(this);
-  if (options) {
-    validateOptions(schema, options, 'Style Loader');
-  } else {
-    options = {};
-  }
 
-	options.hmr = typeof options.hmr === 'undefined' ? true : options.hmr;
-
-	// The variable is needed, because the function should be inlined.
+  // The variable is needed, because the function should be inlined.
 	// If is just stored it in options, JSON.stringify will quote
 	// the function and it would be just a string at runtime
 	var insertInto;
 
-	if (typeof options.insertInto === "function") {
-		insertInto = options.insertInto.toString();
-	}
+  if (options) {
+    validateOptions(schema, options, 'Style Loader');
+    options.hmr = typeof options.hmr === 'undefined' ? true : options.hmr;
 
-	// We need to check if it a string, or variable will be "undefined"
-	// and the loader crashes
-	if (typeof options.insertInto === "string") {
-		insertInto = '"' + options.insertInto + '"';
-	}
+    if (typeof options.insertInto === "function") {
+      insertInto = options.insertInto.toString();
+    }
 
-	var hmr = [
+    // We need to check if it a string, or variable will be "undefined"
+    // and the loader crashes
+    if (typeof options.insertInto === "string") {
+      insertInto = '"' + options.insertInto + '"';
+    }
+  } else {
+    options = { hmr: true };
+  }
+
+	var hmrStr = options.hmr ? [
 		// Hot Module Replacement,
 		"if(module.hot) {",
 		// When the styles change, update the <style> tags
@@ -68,7 +68,7 @@ module.exports.pitch = function (request) {
 		// When the module is disposed, remove the <style> tags
 		"	module.hot.dispose(function() { update(); });",
 		"}"
-	].join("\n");
+	].join("\n") : "";
 
 	return [
 		// Style Loader
@@ -95,6 +95,6 @@ module.exports.pitch = function (request) {
 		"",
 		"if(content.locals) module.exports = content.locals;",
 		"",
-		options.hmr ? hmr : ""
+		hmrStr
 	].join("\n");
 };

--- a/index.js
+++ b/index.js
@@ -6,15 +6,19 @@ var path = require("path");
 
 var loaderUtils = require("loader-utils");
 var validateOptions = require('schema-utils');
+var schema = require('./options.json')
 
 module.exports = function () {};
 
 module.exports.pitch = function (request) {
 	if (this.cacheable) this.cacheable();
 
-	var options = loaderUtils.getOptions(this) || {};
-
-	validateOptions(require('./options.json'), options, 'Style Loader')
+  var options = loaderUtils.getOptions(this);
+  if (options) {
+    validateOptions(schema, options, 'Style Loader');
+  } else {
+    options = {};
+  }
 
 	options.hmr = typeof options.hmr === 'undefined' ? true : options.hmr;
 

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -544,10 +544,10 @@ describe("basic tests", function() {
       // const expectedTansformedStyle = transform(requiredStyle);
       const expected = new TypeError('transform is not a function').message;
 
-      runCompilerTest(expected, done, function() { 
-        try { 
+      runCompilerTest(expected, done, function() {
+        try {
           let test = transform(requiredStyle);
-        } catch(error) { 
+        } catch(error) {
           return error.message;
         } });
     });

--- a/test/validateOptions.test.js
+++ b/test/validateOptions.test.js
@@ -1,0 +1,43 @@
+var loaderUtils = require('loader-utils');
+var assert = require("assert");
+var sinon = require('sinon');
+
+describe('validateOptions', () => {
+  var getOptionsStub;
+  var validateSpy;
+  var styleLoader;
+
+  before(() => {
+    delete require.cache[require.resolve('schema-utils')];
+    delete require.cache[require.resolve('..')];
+    require('schema-utils');
+    validateSpy = sinon.spy(require.cache[require.resolve('schema-utils')], 'exports');
+    styleLoader = require('..');
+    getOptionsStub = sinon.stub(loaderUtils, 'getOptions');
+  });
+
+  beforeEach(() => {
+    validateSpy.resetHistory();
+    getOptionsStub.resetBehavior();
+    getOptionsStub.resetHistory();
+  });
+
+  after(() => {
+    validateSpy.restore();
+    getOptionsStub.restore();
+  });
+
+  it('should not validate undefined options', () => {
+    getOptionsStub.returns();
+    styleLoader.pitch.call({ cacheable() {} }, 'foo');
+    assert(getOptionsStub.calledOnce);
+    assert(validateSpy.notCalled);
+  });
+
+  it('should validate options', () => {
+    getOptionsStub.returns({ insertInto() { console.log('foo'); } });
+    styleLoader.pitch.call({ cacheable() {} }, 'foo');
+    assert(getOptionsStub.calledOnce);
+    assert(validateSpy.calledOnce);
+  });
+})

--- a/test/validateOptions.test.js
+++ b/test/validateOptions.test.js
@@ -6,17 +6,10 @@ describe('validateOptions', () => {
   var getOptionsStub;
   var validateSpy;
   var styleLoader;
+  var urlStyleLoader;
+  var usableStyleLoader;
 
-  before(() => {
-    delete require.cache[require.resolve('schema-utils')];
-    delete require.cache[require.resolve('..')];
-    require('schema-utils');
-    validateSpy = sinon.spy(require.cache[require.resolve('schema-utils')], 'exports');
-    styleLoader = require('..');
-    getOptionsStub = sinon.stub(loaderUtils, 'getOptions');
-  });
-
-  beforeEach(() => {
+  afterEach(() => {
     validateSpy.resetHistory();
     getOptionsStub.resetBehavior();
     getOptionsStub.resetHistory();
@@ -27,17 +20,104 @@ describe('validateOptions', () => {
     getOptionsStub.restore();
   });
 
-  it('should not validate undefined options', () => {
-    getOptionsStub.returns();
-    styleLoader.pitch.call({ cacheable() {} }, 'foo');
-    assert(getOptionsStub.calledOnce);
-    assert(validateSpy.notCalled);
+  before(() => {
+    delete require.cache[require.resolve('schema-utils')];
+    delete require.cache[require.resolve('..')];
+    delete require.cache[require.resolve('../url')];
+    delete require.cache[require.resolve('../useable')];
+    require('schema-utils');
+    validateSpy = sinon.spy(require.cache[require.resolve('schema-utils')], 'exports');
+    styleLoader = require('..');
+    urlStyleLoader = require('../url');
+    usableStyleLoader = require('../useable');
+    getOptionsStub = sinon.stub(loaderUtils, 'getOptions');
   });
 
-  it('should validate options', () => {
-    getOptionsStub.returns({ insertInto() { console.log('foo'); } });
-    styleLoader.pitch.call({ cacheable() {} }, 'foo');
-    assert(getOptionsStub.calledOnce);
-    assert(validateSpy.calledOnce);
+  describe('index', () => {
+
+    it('should not validate in normal', () => {
+      styleLoader.call({ cacheable() {} }, 'foo');
+      assert(getOptionsStub.notCalled);
+      assert(validateSpy.notCalled);
+    });
+
+    it('should not validate undefined options', () => {
+      getOptionsStub.returns();
+      styleLoader.pitch.call({ cacheable() {} }, 'foo');
+      assert(getOptionsStub.calledOnce);
+      assert(validateSpy.notCalled);
+    });
+
+    it('should validate options.insertInto as fn', () => {
+      getOptionsStub.returns({ insertInto() { } })
+      styleLoader.pitch.call({ cacheable() {} }, 'foo');
+      assert(getOptionsStub.calledOnce);
+      assert(validateSpy.calledOnce);
+    });
+
+    it('should validate options.insertInto as str', () => {
+      getOptionsStub.returns({ insertInto: 'bar' })
+      styleLoader.pitch.call({ cacheable() {} }, 'foo');
+      assert(getOptionsStub.calledOnce);
+      assert(validateSpy.calledOnce);
+    });
+  });
+
+  describe('url', () => {
+    it('should not validate in normal', () => {
+      urlStyleLoader.call({ cacheable() {} }, 'foo');
+      assert(getOptionsStub.notCalled);
+      assert(validateSpy.notCalled);
+    });
+
+    it('should not validate undefined options', () => {
+      getOptionsStub.returns();
+      urlStyleLoader.pitch.call({ cacheable() {} }, 'foo');
+      assert(getOptionsStub.calledOnce);
+      assert(validateSpy.notCalled);
+    });
+
+    it('should validate options.insertInto as fn', () => {
+      getOptionsStub.returns({ insertInto() { } })
+      urlStyleLoader.pitch.call({ cacheable() {} }, 'foo');
+      assert(getOptionsStub.calledOnce);
+      assert(validateSpy.calledOnce);
+    });
+
+    it('should validate options.insertInto as str', () => {
+      getOptionsStub.returns({ insertInto: 'bar' })
+      urlStyleLoader.pitch.call({ cacheable() {} }, 'foo');
+      assert(getOptionsStub.calledOnce);
+      assert(validateSpy.calledOnce);
+    });
+  });
+
+  describe('usable', () => {
+    it('should not validate in normal', () => {
+      usableStyleLoader.call({ cacheable() {} }, 'foo');
+      assert(getOptionsStub.notCalled);
+      assert(validateSpy.notCalled);
+    });
+
+    it('should not validate undefined options', () => {
+      getOptionsStub.returns();
+      usableStyleLoader.pitch.call({ cacheable() {} }, 'foo');
+      assert(getOptionsStub.calledOnce);
+      assert(validateSpy.notCalled);
+    });
+
+    it('should validate options.insertInto as fn', () => {
+      getOptionsStub.returns({ insertInto() { } })
+      usableStyleLoader.pitch.call({ cacheable() {} }, 'foo');
+      assert(getOptionsStub.calledOnce);
+      assert(validateSpy.calledOnce);
+    });
+
+    it('should validate options.insertInto as str', () => {
+      getOptionsStub.returns({ insertInto: 'bar' })
+      usableStyleLoader.pitch.call({ cacheable() {} }, 'foo');
+      assert(getOptionsStub.calledOnce);
+      assert(validateSpy.calledOnce);
+    });
   });
 })

--- a/useable.js
+++ b/useable.js
@@ -6,34 +6,41 @@ var path = require('path');
 
 var loaderUtils = require("loader-utils");
 var validateOptions = require('schema-utils');
+var schema = require('./options.json');
+
+var addStylesPath = path.join(__dirname, "lib", "addStyles.js");
 
 module.exports = function () {};
 
 module.exports.pitch = function (request) {
 	if (this.cacheable) this.cacheable();
 
-	var options = loaderUtils.getOptions(this) || {};
-
-	validateOptions(require('./options.json'), options, 'Style Loader (Useable)');
-
-	options.hmr = typeof options.hmr === 'undefined' ? true : options.hmr;
+  var options = loaderUtils.getOptions(this);
 
 	// The variable is needed, because the function should be inlined.
 	// If is just stored it in options, JSON.stringify will quote
 	// the function and it would be just a string at runtime
 	var insertInto;
 
-	if (typeof options.insertInto === "function") {
-		insertInto = options.insertInto.toString();
-	}
+  if (options) {
+    validateOptions(schema, options, 'Style Loader (Useable)');
+    options.hmr = typeof options.hmr === 'undefined' ? true : options.hmr;
 
-	// We need to check if it a string, or variable will be "undefined"
-	// and the loader crashes
-	if (typeof options.insertInto === "string") {
-		insertInto = '"' + options.insertInto + '"';
-	}
+    var insertIntoType = typeof options.insertInto;
+    if (insertIntoType === "function") {
+      insertInto = options.insertInto.toString();
+    }
 
-	var hmr = [
+    // We need to check if it a string, or variable will be "undefined"
+    // and the loader crashes
+    else if (insertIntoType === "string") {
+      insertInto = '"' + options.insertInto + '"';
+    }
+  } else {
+    options = { hmr: true };
+  }
+
+	var hmrStr = options.hmr ? [
 		// Hot Module Replacement
 		"if(module.hot) {",
 		"	var lastRefs = module.hot.data && module.hot.data.refs || 0;",
@@ -57,7 +64,7 @@ module.exports.pitch = function (request) {
 		"		}",
 		"	});",
 		"}"
-	].join("\n");
+	].join("\n") : "";
 
 	return [
 		"var refs = 0;",
@@ -72,7 +79,7 @@ module.exports.pitch = function (request) {
 		"",
 		"exports.use = exports.ref = function() {",
 		"	if(!(refs++)) {",
-		"		dispose = require(" + loaderUtils.stringifyRequest(this, "!" + path.join(__dirname, "lib", "addStyles.js")) + ")(content, options);",
+		"		dispose = require(" + loaderUtils.stringifyRequest(this, "!" + addStylesPath) + ")(content, options);",
 		"	}",
 		"",
 		"	return exports;",
@@ -84,6 +91,6 @@ module.exports.pitch = function (request) {
 		"		 dispose = null;",
 		"  }",
 		"};",
-		options.hmr ? hmr : ""
+		hmrStr
 	].join("\n");
 };


### PR DESCRIPTION
This change aims to improve perf by reducing extraneous called to `validateOptions()` & hoisting `require()`.

**What kind of change does this PR introduce?**
perf

**Did you add tests for your changes?**
Yes

**Summary**

This change aims to improve perf by reducing extraneous called to `validateOptions()` & hoisting `require()`.

**Does this PR introduce a breaking change?**
No
