### PR TITLE
Fix `variable is already defined` error caused in specific situation

### DIFF
--- a/lib/addStyles.js
+++ b/lib/addStyles.js
@@ -90,11 +90,13 @@ module.exports = function(list, options) {
 	addStylesToDom(styles, options);
 
 	return function update (newList) {
+        var i;
+        var domStyle;
 		var mayRemove = [];
 
-		for (var i = 0; i < styles.length; i++) {
+		for (i = 0; i < styles.length; i++) {
 			var item = styles[i];
-			var domStyle = stylesInDom[item.id];
+			domStyle = stylesInDom[item.id];
 
 			domStyle.refs--;
 			mayRemove.push(domStyle);
@@ -105,8 +107,8 @@ module.exports = function(list, options) {
 			addStylesToDom(newStyles, options);
 		}
 
-		for (var i = 0; i < mayRemove.length; i++) {
-			var domStyle = mayRemove[i];
+		for (i = 0; i < mayRemove.length; i++) {
+			domStyle = mayRemove[i];
 
 			if(domStyle.refs === 0) {
 				for (var j = 0; j < domStyle.parts.length; j++) domStyle.parts[j]();
@@ -118,14 +120,15 @@ module.exports = function(list, options) {
 };
 
 function addStylesToDom (styles, options) {
-	for (var i = 0; i < styles.length; i++) {
+    for (var i = 0; i < styles.length; i++) {
+        var j;
 		var item = styles[i];
 		var domStyle = stylesInDom[item.id];
 
 		if(domStyle) {
 			domStyle.refs++;
 
-			for(var j = 0; j < domStyle.parts.length; j++) {
+			for(j = 0; j < domStyle.parts.length; j++) {
 				domStyle.parts[j](item.parts[j]);
 			}
 
@@ -135,7 +138,7 @@ function addStylesToDom (styles, options) {
 		} else {
 			var parts = [];
 
-			for(var j = 0; j < item.parts.length; j++) {
+			for(j = 0; j < item.parts.length; j++) {
 				parts.push(addStyle(item.parts[j], options));
 			}
 

--- a/lib/addStyles.js
+++ b/lib/addStyles.js
@@ -90,8 +90,8 @@ module.exports = function(list, options) {
 	addStylesToDom(styles, options);
 
 	return function update (newList) {
-        var i;
-        var domStyle;
+		var i;
+		var domStyle;
 		var mayRemove = [];
 
 		for (i = 0; i < styles.length; i++) {
@@ -120,8 +120,8 @@ module.exports = function(list, options) {
 };
 
 function addStylesToDom (styles, options) {
-    for (var i = 0; i < styles.length; i++) {
-        var j;
+	for (var i = 0; i < styles.length; i++) {
+		var j;
 		var item = styles[i];
 		var domStyle = stylesInDom[item.id];
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

If you bundle this module without minify, You can see these error : `i is already defined` ,`j is already defined` ,`domStyle is already defined`.

![image](https://user-images.githubusercontent.com/32513370/54902265-3d70ec00-4f1c-11e9-8dc6-2c9aac195e4e.png)


local variables are deleted when the function is completed, not block is completed.
So, This PR fix these multiple declaration.

Usually, loader is minified and packed in eval function so it doesn't matter,but in specific situation *1 that you can't minify code, this issue becomes tangible.

This PR doesn't contain any breaking changes as far as I know.

*1:  For example, to develop UserScript. Post minified UserScript is banned in some site.