### PR TITLE
feat: add insertionTag option

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Styles are not added on `import/require()`, but instead on call to `use`/`ref`. 
 |       **`singleton`**       |     `{Boolean}`      | `undefined` | Reuses a single `<style></style>` element, instead of adding/removing individual elements for each required module.            |
 |       **`sourceMap`**       |     `{Boolean}`      |   `false`   | Enable/Disable Sourcemaps                                                                                                      |
 | **`convertToAbsoluteUrls`** |     `{Boolean}`      |   `false`   | Converts relative URLs to absolute urls, when source maps are enabled                                                          |
-
+| **`insertionTag`** |     `{String}`      |   undefined   | Defines which of the three types of insertion tags to use.  Options are `'style'` to use `<style>` tags, `'link'` to use `<link>` tags or `singleton` to use a single `<style>` tag for all styles.  If left `undefined`, automatic resolution is used, which prefers `<style>` tags unless sourcemaps are used, when it instead prefers `<link>` tags.                                                            |
 ### `hmr`
 
 Enable/disable Hot Module Replacement (HMR), if disabled no HMR Code will be added.

--- a/src/options.json
+++ b/src/options.json
@@ -27,6 +27,10 @@
     },
     "convertToAbsoluteUrls": {
       "type": "boolean"
+    },
+    "insertionTag": {
+      "type": "string",
+      "enum": ["style", "link", "singleton"]
     }
   },
   "additionalProperties": false

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -245,6 +245,159 @@ describe('basic tests', () => {
     runCompilerTest(expected, done);
   });
 
+  it('insertionTag = style', (done) => {
+    // Setup
+    styleLoaderOptions.insertionTag = 'style';
+
+    fs.writeFileSync(
+      `${rootDir}main.js`,
+      [
+        "var a = require('./style.css');",
+        "var b = require('./styleTwo.css');",
+      ].join('\n')
+    );
+
+    // Run
+    const expected = [
+      existingStyle,
+      `<style type="text/css">${requiredCss}</style><style type="text/css">${requiredCssTwo}</style>`,
+    ].join('\n');
+
+    runCompilerTest(expected, done);
+  });
+
+  it('insertionTag = link', (done) => {
+    // Setup
+    styleLoaderOptions.insertionTag = 'link';
+
+    fs.writeFileSync(
+      `${rootDir}main.js`,
+      [
+        "var a = require('./style.css');",
+        "var b = require('./styleTwo.css');",
+      ].join('\n')
+    );
+
+    // Run
+    const expected = [
+      existingStyle,
+      '<link type="text/css" rel="stylesheet" href="fakeJsdomObjectUrl([object Blob])"><link type="text/css" rel="stylesheet" href="fakeJsdomObjectUrl([object Blob])">',
+    ].join('\n');
+
+    runCompilerTest(expected, done);
+  });
+
+  it('insertionTag = singleton', (done) => {
+    styleLoaderOptions.insertionTag = 'singleton';
+
+    fs.writeFileSync(
+      `${rootDir}main.js`,
+      [
+        "var a = require('./style.css');",
+        "var b = require('./styleTwo.css');",
+      ].join('\n')
+    );
+
+    // Run
+    const expected = [
+      existingStyle,
+      `<style type="text/css">${requiredCss}${requiredCssTwo}</style>`,
+    ].join('\n');
+
+    runCompilerTest(expected, done);
+  });
+
+  it('insertionTag = style uses sourceMaps', (done) => {
+    // Setup
+    cssRule.use = [
+      {
+        loader: 'style-loader',
+        options: {
+          sourceMap: true,
+          insertionTag: 'style',
+        },
+      },
+      {
+        loader: 'css-loader',
+        options: { sourceMap: true },
+      },
+    ];
+    setupWebpackConfig();
+
+    fs.writeFileSync(
+      `${rootDir}main.js`,
+      [
+        "var a = require('./style.css');",
+        "var b = require('./styleTwo.css');",
+      ].join('\n')
+    );
+    // Run
+    const expected = [
+      existingStyle,
+      `\n<style type="text/css">${requiredCss}\n`,
+      '/*# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInN0eWxlLmNzcyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQSxZQUFZLFlBQVkiLCJmaWxlIjoic3R5bGUuY3NzIiwic291cmNlc0NvbnRlbnQiOlsiLnJlcXVpcmVkIHsgY29sb3I6IGJsdWUgfSJdfQ== */</style>',
+      `<style type="text/css">${requiredCssTwo}\n`,
+      '/*# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInN0eWxlVHdvLmNzcyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQSxlQUFlLFlBQVkiLCJmaWxlIjoic3R5bGVUd28uY3NzIiwic291cmNlc0NvbnRlbnQiOlsiLnJlcXVpcmVkVHdvIHsgY29sb3I6IGN5YW4gfSJdfQ== */</style>',
+    ].join('');
+
+    runCompilerTest(expected, done);
+  });
+
+  it('insertionTag = style respects options.sourceMap value', (done) => {
+    // Setup
+    cssRule.use = [
+      {
+        loader: 'style-loader',
+        options: {
+          sourceMap: false,
+          insertionTag: 'style',
+        },
+      },
+      {
+        loader: 'css-loader',
+        options: { sourceMap: true },
+      },
+    ];
+    setupWebpackConfig();
+
+    fs.writeFileSync(
+      `${rootDir}main.js`,
+      [
+        "var a = require('./style.css');",
+        "var b = require('./styleTwo.css');",
+      ].join('\n')
+    );
+    // Run
+    const expected = [
+      existingStyle,
+      `<style type="text/css">${requiredCss}</style><style type="text/css">${requiredCssTwo}</style>`,
+    ].join('\n');
+
+    runCompilerTest(expected, done);
+  });
+
+  it('insertionTag overrides options.singleton', (done) => {
+    // Setup
+    styleLoaderOptions.singleton = true;
+    styleLoaderOptions.insertionTag = 'style';
+
+    fs.writeFileSync(
+      `${rootDir}main.js`,
+      [
+        "var a = require('./style.css');",
+        "var b = require('./styleTwo.css');",
+      ].join('\n')
+    );
+
+    // Run
+    const expected = [
+      existingStyle,
+      `<style type="text/css">${requiredCss}</style><style type="text/css">${requiredCssTwo}</style>`,
+    ].join('\n');
+
+    runCompilerTest(expected, done);
+  });
+
   it('attrs', (done) => {
     // Setup
     styleLoaderOptions.attrs = { id: 'style-tag-id' };

--- a/test/utils.js
+++ b/test/utils.js
@@ -82,7 +82,9 @@ module.exports = {
           runScripts: 'dangerously',
           virtualConsole,
         });
-
+        // JSDom doesn't implement these.
+        window.URL.createObjectURL = (arg) => `fakeJsdomObjectUrl(${arg})`;
+        window.URL.revokeObjectURL = () => {};
         window.eval(bundleJs);
 
         if (typeof actual === 'function') {


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

There are numerous bug reports around the net about flashes of unstyled content (FOUC) when using style-loader with sourcemaps:
https://github.com/facebook/create-react-app/issues/6399
https://github.com/webpack-contrib/css-loader/issues/613
https://stackoverflow.com/questions/36453826/how-to-stop-fouc-when-using-css-loaded-by-webpack
https://github.com/webpack/webpack-dev-middleware/issues/51

Ultimately, all of these are caused by two things:
1. Style loader chooses `<link>` elements when using sourcemaps, and those `<link>` elements are evaluated async, so the HTML may be rendered before the CSS.
2. Style loader doesn't support adding sourcemaps on `<style>` elements, so if you want sourcemaps, you end up with FOUCs.

This change allows you to explicitly specify that you want to use `<style>` elements or `<link>` elements, or singleton `<style>` elements.  It also adds support for putting sourcemaps into `<style>` elements, which works great in Chrome.

### Breaking Changes

None, existing behavior is preserved if you don't pass the `insertionTag` option.

### Additional Info

Other stuff I noticed:

There were no tests for `<link>` element rendering.  I added one, and had to mock a couple of missing methods on URL from JSDOM to do so. 

Also, the documented `sourceMap` option didn't  do anything.  The only place sourceMaps were used was in the `<link>` element code and it was looking at the object passed in from the `css-loader` and not the options.  I left that as-is to preserve backward compatibility, but when adding support for source maps to `<style>` tags, I made it work as per the docs, based on the `sourceMap` option flag.   I'm not sure if that's the right thing to do or to remove the do-nothing `sourceMap` option from the docs entirely and just rely on the upstream loader having passed a sourcemap or not.

Another question that might be worth discussion, if 'singleton' is only there for old IE, and modern browsers support sourcemaps in `<style>` tags, a "legacy free" version of this loader might be nice.  It could cut down on the size and complexity and just support `<style>` tags, necessitating less options and less code.
