### PR TITLE
refactor: rename `attrs` option to `attributes`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,38 +20,48 @@ Adds CSS to the DOM by injecting a <code>&lt;style&gt;</code> tag
 
 ## Getting Started
 
-```bash
-npm install style-loader --save-dev
+To begin, you'll need to install `css-loader`:
+
+```console
+npm install --save-dev style-loader
 ```
 
-<h2 align="center">Usage</h2>
+It's recommended to combine `style-loader` with the [`css-loader`](https://github.com/webpack-contrib/css-loader)
 
-It's recommended to combine `style-loader` with the [`css-loader`](https://github.com/webpack/css-loader)
+Then add the loader to your `webpack` config. For example:
+
+**style.css**
+
+```css
+body {
+  background: green;
+}
+```
 
 **component.js**
 
 ```js
-import style from './file.css';
+import style from './style.css';
 ```
 
 **webpack.config.js**
 
 ```js
-{
+module.exports = {
   module: {
     rules: [
       {
-        test: /\.css$/,
+        test: /\.css$/i,
         use: [{ loader: 'style-loader' }, { loader: 'css-loader' }],
       },
     ],
-  }
-}
+  },
+};
 ```
 
-#### `Locals (CSS Modules)`
+### `Locals (CSS Modules)`
 
-When using [local scoped CSS](https://github.com/webpack/css-loader#css-scope) the module exports the generated identifiers (locals).
+When using [local scoped CSS](https://github.com/webpack/css-loader#css-scope) the module exports the generated identifiers (locals):
 
 **component.js**
 
@@ -72,7 +82,7 @@ import url from 'file.css';
 **webpack.config.js**
 
 ```js
-{
+module.exports = {
   module: {
     rules: [
       {
@@ -80,8 +90,8 @@ import url from 'file.css';
         use: [{ loader: 'style-loader/url' }, { loader: 'file-loader' }],
       },
     ],
-  }
-}
+  },
+};
 ```
 
 ```html
@@ -97,29 +107,26 @@ By convention the `Reference Counter API` should be bound to `.useable.css` and 
 **webpack.config.js**
 
 ```js
-{
+module.exports = {
   module: {
     rules: [
       {
         test: /\.css$/,
         exclude: /\.useable\.css$/,
-        use: [
-          { loader: "style-loader" },
-          { loader: "css-loader" },
-        ],
+        use: [{ loader: 'style-loader' }, { loader: 'css-loader' }],
       },
       {
         test: /\.useable\.css$/,
         use: [
           {
-            loader: "style-loader/useable"
+            loader: 'style-loader/useable',
           },
-          { loader: "css-loader" },
+          { loader: 'css-loader' },
         ],
       },
     ],
   },
-}
+};
 ```
 
 #### `Reference Counter API`
@@ -143,7 +150,7 @@ Styles are not added on `import/require()`, but instead on call to `use`/`ref`. 
 | :--------------: | :------------------: | :---------: | :----------------------------------------------------------------------------------------------------------------------------- |
 |    **`hmr`**     |     `{Boolean}`      |   `true`    | Enable/disable Hot Module Replacement (HMR), if disabled no HMR Code will be added (good for non local development/production) |
 |    **`base`**    |      `{Number}`      |   `true`    | Set module ID base (DLLPlugin)                                                                                                 |
-|   **`attrs`**    |      `{Object}`      |    `{}`     | Add custom attrs to `<style></style>`                                                                                          |
+| **`attributes`** |      `{Object}`      |    `{}`     | Add custom attributes to `<style></style>`                                                                                     |
 | **`transform`**  |     `{Function}`     |   `false`   | Transform/Conditionally load CSS by passing a transform/condition function                                                     |
 |  **`insertAt`**  |  `{String\|Object}`  |  `bottom`   | Inserts `<style></style>` at the given position                                                                                |
 | **`insertInto`** | `{String\|Function}` |  `<head>`   | Inserts `<style></style>` into the given position                                                                              |
@@ -158,12 +165,24 @@ This could be used for non local development and production.
 **webpack.config.js**
 
 ```js
-{
-  loader: 'style-loader',
-  options: {
-    hmr: false
-  }
-}
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.css$/i,
+        use: [
+          {
+            loader: 'style-loader',
+            options: {
+              hmr: false,
+            },
+          },
+          { loader: 'css-loader' },
+        ],
+      },
+    ],
+  },
+};
 ```
 
 ### `base`
@@ -173,40 +192,60 @@ This setting is primarily used as a workaround for [css clashes](https://github.
 **webpack.dll1.config.js**
 
 ```js
-{
-  test: /\.css$/,
-  use: [
-    'style-loader',
-    'css-loader'
-  ]
-}
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.css$/i,
+        use: [
+          {
+            loader: 'style-loader',
+          },
+          { loader: 'css-loader' },
+        ],
+      },
+    ],
+  },
+};
 ```
 
 **webpack.dll2.config.js**
 
 ```js
-{
-  test: /\.css$/,
-  use: [
-    { loader: 'style-loader', options: { base: 1000 } },
-    'css-loader'
-  ]
-}
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.css$/,
+        use: [
+          { loader: 'style-loader', options: { base: 1000 } },
+          { loader: 'css-loader' },
+        ],
+      },
+    ],
+  },
+};
 ```
 
 **webpack.app.config.js**
 
-```
-{
-  test: /\.css$/,
-  use: [
-    { loader: 'style-loader', options: { base: 2000 } },
-    'css-loader'
-  ]
-}
+```js
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.css$/,
+        use: [
+          { loader: 'style-loader', options: { base: 2000 } },
+          { loader: 'css-loader' },
+        ],
+      },
+    ],
+  },
+};
 ```
 
-### `attrs`
+### `attributes`
 
 If defined, style-loader will attach given attributes with their values on `<style>` / `<link>` element.
 
@@ -219,13 +258,19 @@ import style from './file.css';
 **webpack.config.js**
 
 ```js
-{
-  test: /\.css$/,
-  use: [
-    { loader: 'style-loader', options: { attrs: { id: 'id' } } }
-    { loader: 'css-loader' }
-  ]
-}
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.css$/,
+        use: [
+          { loader: 'style-loader', options: { attributes: { id: 'id' } } },
+          { loader: 'css-loader' },
+        ],
+      },
+    ],
+  },
+};
 ```
 
 ```html
@@ -243,13 +288,19 @@ import link from './file.css';
 **webpack.config.js**
 
 ```js
-{
-  test: /\.css$/,
-  use: [
-    { loader: 'style-loader/url', options: { attrs: { id: 'id' } } }
-    { loader: 'file-loader' }
-  ]
-}
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.css$/,
+        use: [
+          { loader: 'style-loader/url', options: { attributes: { id: 'id' } } },
+          { loader: 'file-loader' },
+        ],
+      },
+    ],
+  },
+};
 ```
 
 ### `transform`
@@ -263,12 +314,19 @@ If the return value of the `transform` function is falsy, the css will not be lo
 **webpack.config.js**
 
 ```js
-{
-  loader: 'style-loader',
-  options: {
-    transform: 'path/to/transform.js'
-  }
-}
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.css$/i,
+        loader: 'style-loader',
+        options: {
+          transform: 'path/to/transform.js',
+        },
+      },
+    ],
+  },
+};
 ```
 
 **transform.js**
@@ -276,9 +334,7 @@ If the return value of the `transform` function is falsy, the css will not be lo
 ```js
 module.exports = function(css) {
   // Here we can change the original css
-  const transformed = css.replace('.classNameA', '.classNameB');
-
-  return transformed;
+  return css.replace('.classNameA', '.classNameB');
 };
 ```
 
@@ -287,12 +343,19 @@ module.exports = function(css) {
 **webpack.config.js**
 
 ```js
-{
-  loader: 'style-loader',
-  options: {
-    transform: 'path/to/conditional.js'
-  }
-}
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.css$/i,
+        loader: 'style-loader',
+        options: {
+          transform: 'path/to/conditional.js',
+        },
+      },
+    ],
+  },
+};
 ```
 
 **conditional.js**
@@ -303,6 +366,7 @@ module.exports = function(css) {
   if (css.includes('something I want to check')) {
     return css;
   }
+
   // If a falsy value is returned, the CSS won't be loaded
   return false;
 };
@@ -315,12 +379,24 @@ By default, the style-loader appends `<style>` elements to the end of the style 
 **webpack.config.js**
 
 ```js
-{
-  loader: 'style-loader',
-  options: {
-    insertAt: 'top'
-  }
-}
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.css$/i,
+        use: [
+          {
+            loader: 'style-loader',
+            options: {
+              insertAt: 'top',
+            },
+          },
+          { loader: 'css-loader' },
+        ],
+      },
+    ],
+  },
+};
 ```
 
 A new `<style>` element can be inserted before a specific element by passing an object, e.g.
@@ -328,14 +404,26 @@ A new `<style>` element can be inserted before a specific element by passing an 
 **webpack.config.js**
 
 ```js
-{
-  loader: 'style-loader',
-  options: {
-    insertAt: {
-        before: '#id'
-    }
-  }
-}
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.css$/i,
+        use: [
+          {
+            loader: 'style-loader',
+            options: {
+              insertAt: {
+                before: '#id',
+              },
+            },
+          },
+          { loader: 'css-loader' },
+        ],
+      },
+    ],
+  },
+};
 ```
 
 ### `insertInto`
@@ -347,12 +435,24 @@ You can also pass function to override default behavior and insert styles in you
 **webpack.config.js**
 
 ```js
-{
-  loader: 'style-loader',
-  options: {
-    insertInto: () => document.querySelector("#root"),
-  }
-}
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.css$/i,
+        use: [
+          {
+            loader: 'style-loader',
+            options: {
+              insertInto: () => document.querySelector('#root'),
+            },
+          },
+          { loader: 'css-loader' },
+        ],
+      },
+    ],
+  },
+};
 ```
 
 Using function you can insert the styles into a [ShadowRoot](https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot), e.g
@@ -360,12 +460,24 @@ Using function you can insert the styles into a [ShadowRoot](https://developer.m
 **webpack.config.js**
 
 ```js
-{
-  loader: 'style-loader',
-  options: {
-    insertInto: () => document.querySelector("#root").shadowRoot,
-  }
-}
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.css$/i,
+        use: [
+          {
+            loader: 'style-loader',
+            options: {
+              insertInto: () => document.querySelector('#root').shadowRoot,
+            },
+          },
+          { loader: 'css-loader' },
+        ],
+      },
+    ],
+  },
+};
 ```
 
 ### `singleton`
@@ -377,12 +489,19 @@ If defined, the style-loader will reuse a single `<style></style>` element, inst
 **webpack.config.js**
 
 ```js
-{
-  loader: 'style-loader',
-  options: {
-    singleton: true
-  }
-}
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.css$/i,
+        use: [
+          { loader: 'style-loader', options: { singleton: true } },
+          { loader: 'css-loader' },
+        ],
+      },
+    ],
+  },
+};
 ```
 
 ### `sourceMap`
@@ -392,12 +511,19 @@ Enable/Disable source map loading
 **webpack.config.js**
 
 ```js
-{
-  loader: 'style-loader',
-  options: {
-    sourceMap: true
-  }
-}
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.css$/i,
+        use: [
+          { loader: 'style-loader', options: { sourceMap: true } },
+          { loader: 'css-loader', options: { sourceMap: true } },
+        ],
+      },
+    ],
+  },
+};
 ```
 
 ## Contributing

--- a/src/options.json
+++ b/src/options.json
@@ -9,8 +9,8 @@
       "description": "Set module ID base for DLLPlugin (https://github.com/webpack-contrib/style-loader#base).",
       "type": "number"
     },
-    "attrs": {
-      "description": "Add custom attrs to <style></style> (https://github.com/webpack-contrib/style-loader#attrs).",
+    "attributes": {
+      "description": "Add custom attributes to tag (https://github.com/webpack-contrib/style-loader#attributes).",
       "type": "object"
     },
     "insertAt": {

--- a/src/runtime/addStyleUrl.js
+++ b/src/runtime/addStyleUrl.js
@@ -1,12 +1,6 @@
 /* eslint-env browser */
 /* eslint-disable */
 
-function addAttrs(element, attrs) {
-  Object.keys(attrs).forEach((key) => {
-    element.setAttribute(key, attrs[key]);
-  });
-}
-
 module.exports = function addStyleUrl(url, options) {
   /* istanbul ignore if  */
   if (typeof DEBUG !== 'undefined' && DEBUG) {
@@ -19,7 +13,8 @@ module.exports = function addStyleUrl(url, options) {
 
   options = options || {};
 
-  options.attrs = typeof options.attrs === 'object' ? options.attrs : {};
+  options.attributes =
+    typeof options.attributes === 'object' ? options.attributes : {};
   options.hmr = typeof options.hmr === 'undefined' ? true : options.hmr;
 
   const link = document.createElement('link');
@@ -28,7 +23,9 @@ module.exports = function addStyleUrl(url, options) {
   link.type = 'text/css';
   link.href = url;
 
-  addAttrs(link, options.attrs);
+  Object.keys(options.attributes).forEach((key) => {
+    link.setAttribute(key, options.attributes[key]);
+  });
 
   const head = document.getElementsByTagName('head')[0];
 

--- a/src/runtime/addStyles.js
+++ b/src/runtime/addStyles.js
@@ -85,7 +85,8 @@ module.exports = function(list, options) {
 
   options = options || {};
 
-  options.attrs = typeof options.attrs === 'object' ? options.attrs : {};
+  options.attributes =
+    typeof options.attributes === 'object' ? options.attributes : {};
 
   // Force single-tag solution on IE6-9, which has a hard limit on the # of <style>
   // tags it will allow on a page
@@ -241,20 +242,20 @@ function removeStyleElement(style) {
 function createStyleElement(options) {
   var style = document.createElement('style');
 
-  if (options.attrs.type === undefined) {
-    options.attrs.type = 'text/css';
+  if (options.attributes.type === undefined) {
+    options.attributes.type = 'text/css';
   }
 
-  if (options.attrs.nonce === undefined) {
+  if (options.attributes.nonce === undefined) {
     var nonce = getNonce();
 
     if (nonce) {
-      options.attrs.nonce = nonce;
+      options.attributes.nonce = nonce;
     }
   }
 
-  Object.keys(options.attrs).forEach((key) => {
-    style.setAttribute(key, options.attrs[key]);
+  Object.keys(options.attributes).forEach((key) => {
+    style.setAttribute(key, options.attributes[key]);
   });
 
   insertStyleElement(options, style);

--- a/test/__snapshots__/validate-options.test.js.snap
+++ b/test/__snapshots__/validate-options.test.js.snap
@@ -14,9 +14,9 @@ exports[`validate options 2`] = `
 
 exports[`validate options 3`] = `
 "Invalid options object. Style Loader has been initialised using an options object that does not match the API schema.
- - options.attrs should be an object:
+ - options.attributes should be an object:
    object { … }
-   -> Add custom attrs to <style></style> (https://github.com/webpack-contrib/style-loader#attrs)."
+   -> Add custom attributes to tag (https://github.com/webpack-contrib/style-loader#attributes)."
 `;
 
 exports[`validate options 4`] = `
@@ -57,5 +57,5 @@ exports[`validate options 8`] = `
 exports[`validate options 9`] = `
 "Invalid options object. Style Loader has been initialised using an options object that does not match the API schema.
  - options has an unknown property 'unknown'. These properties are valid:
-   object { hmr?, base?, attrs?, insertAt?, insertInto?, transform?, singleton?, sourceMap? }"
+   object { hmr?, base?, attributes?, insertAt?, insertInto?, transform?, singleton?, sourceMap? }"
 `;

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -249,9 +249,9 @@ describe('basic tests', () => {
     runCompilerTest(expected, done);
   });
 
-  it('attrs', (done) => {
+  it('attributes', (done) => {
     // Setup
-    styleLoaderOptions.attrs = { id: 'style-tag-id' };
+    styleLoaderOptions.attributes = { id: 'style-tag-id' };
 
     fs.writeFileSync(
       `${rootDir}main.js`,
@@ -261,7 +261,7 @@ describe('basic tests', () => {
     // Run
     const expected = [
       existingStyle,
-      `<style id="${styleLoaderOptions.attrs.id}" type="text/css">${requiredCss}</style>`,
+      `<style id="${styleLoaderOptions.attributes.id}" type="text/css">${requiredCss}</style>`,
     ].join('\n');
 
     runCompilerTest(expected, done);
@@ -290,7 +290,7 @@ describe('basic tests', () => {
 
   it('type attribute', (done) => {
     // Setup
-    styleLoaderOptions.attrs = { type: 'text/less' };
+    styleLoaderOptions.attributes = { type: 'text/less' };
 
     fs.writeFileSync(
       `${rootDir}main.js`,
@@ -300,7 +300,7 @@ describe('basic tests', () => {
     // Run
     const expected = [
       existingStyle,
-      `<style type="${styleLoaderOptions.attrs.type}">${requiredCss}</style>`,
+      `<style type="${styleLoaderOptions.attributes.type}">${requiredCss}</style>`,
     ].join('\n');
 
     runCompilerTest(expected, done);
@@ -324,12 +324,12 @@ describe('basic tests', () => {
     runCompilerTest(expected, done);
   });
 
-  it('url with attrs', (done) => {
+  it('url with attributes', (done) => {
     cssRule.use = [
       {
         loader: path.resolve(__dirname, '../src/url-loader.js'),
         options: {
-          attrs: {
+          attributes: {
             'data-attr-1': 'attr-value-1',
             'data-attr-2': 'attr-value-2',
           },
@@ -352,7 +352,7 @@ describe('basic tests', () => {
       {
         loader: path.resolve(__dirname, '../src/url-loader.js'),
         options: {
-          attrs: {
+          attributes: {
             type: 'text/less',
           },
         },

--- a/test/runtime/__snapshots__/addStyle.test.js.snap
+++ b/test/runtime/__snapshots__/addStyle.test.js.snap
@@ -25,9 +25,9 @@ exports[`addStyle should work #2 1`] = `"<head><title>Title</title><style type=\
 
 exports[`addStyle should work 1`] = `"<head><title>Title</title><style type=\\"text/css\\">.foo { color: red }</style></head><body><h1>Hello world</h1></body>"`;
 
-exports[`addStyle should work with "attrs" option #2 1`] = `"<head><title>Title</title><style foo=\\"bar\\" type=\\"text/css\\">.foo { color: red }</style><style foo=\\"bar\\" type=\\"text/css\\">.bar { color: blue }</style></head><body><h1>Hello world</h1></body>"`;
+exports[`addStyle should work with "attributes" option #2 1`] = `"<head><title>Title</title><style foo=\\"bar\\" type=\\"text/css\\">.foo { color: red }</style><style foo=\\"bar\\" type=\\"text/css\\">.bar { color: blue }</style></head><body><h1>Hello world</h1></body>"`;
 
-exports[`addStyle should work with "attrs" option 1`] = `"<head><title>Title</title><style foo=\\"bar\\" type=\\"text/css\\">.foo { color: red }</style></head><body><h1>Hello world</h1></body>"`;
+exports[`addStyle should work with "attributes" option 1`] = `"<head><title>Title</title><style foo=\\"bar\\" type=\\"text/css\\">.foo { color: red }</style></head><body><h1>Hello world</h1></body>"`;
 
 exports[`addStyle should work with "base" option 1`] = `"<head><title>Title</title><style type=\\"text/css\\">.foo { color: red }</style></head><body><h1>Hello world</h1></body>"`;
 

--- a/test/runtime/__snapshots__/addStyleUrl.test.js.snap
+++ b/test/runtime/__snapshots__/addStyleUrl.test.js.snap
@@ -2,4 +2,4 @@
 
 exports[`addStyle should work 1`] = `"<head><title>Title</title><link rel=\\"stylesheet\\" type=\\"text/css\\" href=\\"./style-1.css\\"></head><body><h1>Hello world</h1></body>"`;
 
-exports[`addStyle should work with "attrs" option 1`] = `"<head><title>Title</title><link rel=\\"stylesheet\\" type=\\"text/css\\" href=\\"./style-1.css\\" foo=\\"bar\\"></head><body><h1>Hello world</h1></body>"`;
+exports[`addStyle should work with "attributes" option 1`] = `"<head><title>Title</title><link rel=\\"stylesheet\\" type=\\"text/css\\" href=\\"./style-1.css\\" foo=\\"bar\\"></head><body><h1>Hello world</h1></body>"`;

--- a/test/runtime/addStyle.test.js
+++ b/test/runtime/addStyle.test.js
@@ -37,22 +37,22 @@ describe('addStyle', () => {
     expect(document.documentElement.innerHTML).toMatchSnapshot();
   });
 
-  it('should work with "attrs" option', () => {
+  it('should work with "attributes" option', () => {
     addStyle([['./style-3.css', '.foo { color: red }', '']], {
-      attrs: { foo: 'bar' },
+      attributes: { foo: 'bar' },
     });
 
     expect(document.documentElement.innerHTML).toMatchSnapshot();
   });
 
-  it('should work with "attrs" option #2', () => {
+  it('should work with "attributes" option #2', () => {
     addStyle(
       [
         ['./style-4-1.css', '.foo { color: red }', ''],
         ['./style-4-2.css', '.bar { color: blue }', ''],
       ],
       {
-        attrs: { foo: 'bar' },
+        attributes: { foo: 'bar' },
       }
     );
 

--- a/test/runtime/addStyleUrl.test.js
+++ b/test/runtime/addStyleUrl.test.js
@@ -16,8 +16,8 @@ describe('addStyle', () => {
     expect(document.documentElement.innerHTML).toMatchSnapshot();
   });
 
-  it('should work with "attrs" option', () => {
-    addStyleUrl('./style-1.css', { attrs: { foo: 'bar' } });
+  it('should work with "attributes" option', () => {
+    addStyleUrl('./style-1.css', { attributes: { foo: 'bar' } });
 
     expect(document.documentElement.innerHTML).toMatchSnapshot();
   });

--- a/test/validate-options.test.js
+++ b/test/validate-options.test.js
@@ -27,9 +27,9 @@ it('validate options', () => {
   expect(() => validate({ base: 1000 })).not.toThrow();
   expect(() => validate({ base: 'unknown' })).toThrowErrorMatchingSnapshot();
 
-  expect(() => validate({ attrs: {} })).not.toThrow();
-  expect(() => validate({ attrs: { attrs: { id: 'id' } } })).not.toThrow();
-  expect(() => validate({ attrs: true })).toThrowErrorMatchingSnapshot();
+  expect(() => validate({ attributes: {} })).not.toThrow();
+  expect(() => validate({ attributes: { id: 'id' } })).not.toThrow();
+  expect(() => validate({ attributes: true })).toThrowErrorMatchingSnapshot();
 
   expect(() => validate({ transform: 'path/to/transform.js' })).not.toThrow();
   expect(() => validate({ transform: true })).toThrowErrorMatchingSnapshot();


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [x] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Rename `attrs` to `attributes`

### Breaking Changes

Yes

BREAKING CHANGE: `attrs` options was renamed to `attributes`

### Additional Info

No