### PR TITLE
refactor: remove `transform` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,6 @@ Styles are not added on `import/require()`, but instead on call to `use`/`ref`. 
 |    **`hmr`**     |     `{Boolean}`      |   `true`    | Enable/disable Hot Module Replacement (HMR), if disabled no HMR Code will be added (good for non local development/production) |
 |    **`base`**    |      `{Number}`      |   `true`    | Set module ID base (DLLPlugin)                                                                                                 |
 | **`attributes`** |      `{Object}`      |    `{}`     | Add custom attributes to `<style></style>`                                                                                     |
-| **`transform`**  |     `{Function}`     |   `false`   | Transform/Conditionally load CSS by passing a transform/condition function                                                     |
 |  **`insertAt`**  |  `{String\|Object}`  |  `bottom`   | Inserts `<style></style>` at the given position                                                                                |
 | **`insertInto`** | `{String\|Function}` |  `<head>`   | Inserts `<style></style>` into the given position                                                                              |
 | **`singleton`**  |     `{Boolean}`      | `undefined` | Reuses a single `<style></style>` element, instead of adding/removing individual elements for each required module.            |
@@ -300,75 +299,6 @@ module.exports = {
       },
     ],
   },
-};
-```
-
-### `transform`
-
-A `transform` is a function that can modify the css just before it is loaded into the page by the style-loader.
-This function will be called on the css that is about to be loaded and the return value of the function will be loaded into the page instead of the original css.
-If the return value of the `transform` function is falsy, the css will not be loaded into the page at all.
-
-> ⚠️ In case you are using ES Module syntax in `tranform.js` then, you **need to transpile** it or otherwise it will throw an `{Error}`.
-
-**webpack.config.js**
-
-```js
-module.exports = {
-  module: {
-    rules: [
-      {
-        test: /\.css$/i,
-        loader: 'style-loader',
-        options: {
-          transform: 'path/to/transform.js',
-        },
-      },
-    ],
-  },
-};
-```
-
-**transform.js**
-
-```js
-module.exports = function(css) {
-  // Here we can change the original css
-  return css.replace('.classNameA', '.classNameB');
-};
-```
-
-#### `Conditional`
-
-**webpack.config.js**
-
-```js
-module.exports = {
-  module: {
-    rules: [
-      {
-        test: /\.css$/i,
-        loader: 'style-loader',
-        options: {
-          transform: 'path/to/conditional.js',
-        },
-      },
-    ],
-  },
-};
-```
-
-**conditional.js**
-
-```js
-module.exports = function(css) {
-  // If the condition is matched load [and transform] the CSS
-  if (css.includes('something I want to check')) {
-    return css;
-  }
-
-  // If a falsy value is returned, the CSS won't be loaded
-  return false;
 };
 ```
 

--- a/src/index.js
+++ b/src/index.js
@@ -83,20 +83,10 @@ module.exports.pitch = function loader(request) {
     '',
     "if(typeof content === 'string') content = [[module.id, content, '']];",
     '',
-    // Transform styles",
-    'var transform;',
     'var insertInto;',
-    '',
-    options.transform
-      ? `transform = require(${loaderUtils.stringifyRequest(
-          this,
-          `!${path.resolve(options.transform)}`
-        )});`
-      : '',
     '',
     `var options = ${JSON.stringify(options)}`,
     '',
-    'options.transform = transform',
     `options.insertInto = ${insertInto};`,
     '',
     // Add styles to the DOM

--- a/src/options.json
+++ b/src/options.json
@@ -21,10 +21,6 @@
       "description": "Inserts <style></style> into the given position (https://github.com/webpack-contrib/style-loader#insertinto).",
       "anyOf": [{ "type": "string" }, { "instanceof": "Function" }]
     },
-    "transform": {
-      "description": "Transform/Conditionally load CSS by passing a transform/condition function (https://github.com/webpack-contrib/style-loader#transform).",
-      "type": "string"
-    },
     "singleton": {
       "description": "Reuses a single <style></style> element, instead of adding/removing individual elements for each required module (https://github.com/webpack-contrib/style-loader#singleton).",
       "type": "boolean"

--- a/src/runtime/addStyles.js
+++ b/src/runtime/addStyles.js
@@ -274,27 +274,6 @@ function getNonce() {
 function addStyle(obj, options) {
   var style, update, remove, result;
 
-  // If a transform function was defined, run it on the css
-  if (options.transform && obj.css) {
-    result =
-      typeof options.transform === 'function'
-        ? options.transform(obj.css)
-        : // ES3 compatibility
-          options.transform['default'](obj.css);
-
-    if (result) {
-      // If transform returns a value, use that instead of the original css.
-      // This allows running runtime transformations on the css.
-      obj.css = result;
-    } else {
-      // If the transform function returns a falsy value, don't add this css.
-      // This allows conditional loading of css
-      return function() {
-        // noop
-      };
-    }
-  }
-
   if (options.singleton) {
     var styleIndex = singletonCounter++;
 

--- a/test/__snapshots__/validate-options.test.js.snap
+++ b/test/__snapshots__/validate-options.test.js.snap
@@ -21,18 +21,12 @@ exports[`validate options 3`] = `
 
 exports[`validate options 4`] = `
 "Invalid options object. Style Loader has been initialised using an options object that does not match the API schema.
- - options.transform should be a string.
-   -> Transform/Conditionally load CSS by passing a transform/condition function (https://github.com/webpack-contrib/style-loader#transform)."
-`;
-
-exports[`validate options 5`] = `
-"Invalid options object. Style Loader has been initialised using an options object that does not match the API schema.
  - options.insertAt should be:
    string | object
    -> Inserts <style></style> at the given position (https://github.com/webpack-contrib/style-loader#insertat)."
 `;
 
-exports[`validate options 6`] = `
+exports[`validate options 5`] = `
 "Invalid options object. Style Loader has been initialised using an options object that does not match the API schema.
  - options.insertInto should be one of these:
    string | function
@@ -42,20 +36,20 @@ exports[`validate options 6`] = `
     * options.insertInto should be an instance of function."
 `;
 
-exports[`validate options 7`] = `
+exports[`validate options 6`] = `
 "Invalid options object. Style Loader has been initialised using an options object that does not match the API schema.
  - options.singleton should be a boolean.
    -> Reuses a single <style></style> element, instead of adding/removing individual elements for each required module (https://github.com/webpack-contrib/style-loader#singleton)."
 `;
 
-exports[`validate options 8`] = `
+exports[`validate options 7`] = `
 "Invalid options object. Style Loader has been initialised using an options object that does not match the API schema.
  - options.sourceMap should be a boolean.
    -> Enable/Disable Sourcemaps (https://github.com/webpack-contrib/style-loader#sourcemap)."
 `;
 
-exports[`validate options 9`] = `
+exports[`validate options 8`] = `
 "Invalid options object. Style Loader has been initialised using an options object that does not match the API schema.
  - options has an unknown property 'unknown'. These properties are valid:
-   object { hmr?, base?, attributes?, insertAt?, insertInto?, transform?, singleton?, sourceMap? }"
+   object { hmr?, base?, attributes?, insertAt?, insertInto?, singleton?, sourceMap? }"
 `;

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -535,65 +535,6 @@ describe('basic tests', () => {
     });
   });
 
-  describe('transform function', () => {
-    it('should not load the css if the transform function returns false', (done) => {
-      styleLoaderOptions.transform = 'test/transforms/false';
-
-      runCompilerTest(existingStyle, done);
-    });
-
-    it('should not load the css if the transform function returns undefined', (done) => {
-      styleLoaderOptions.transform = 'test/transforms/noop';
-
-      runCompilerTest(existingStyle, done);
-    });
-
-    it('should load the transformed css returned by the transform function', (done) => {
-      // eslint-disable-next-line global-require
-      const transform = require('./transforms/transform');
-
-      styleLoaderOptions.transform = 'test/transforms/transform';
-
-      const expectedTansformedStyle = transform(requiredStyle);
-      const expected = [existingStyle, expectedTansformedStyle].join('\n');
-
-      runCompilerTest(expected, done);
-    });
-
-    it('es6 export: should throw error transform is not a function', (done) => {
-      // eslint-disable-next-line global-require
-      const transform = require('./transforms/transform_es6');
-
-      styleLoaderOptions.transform = 'test/transforms/transform_es6';
-
-      // const expectedTansformedStyle = transform(requiredStyle);
-      const expected = new TypeError('transform is not a function').message;
-
-      // eslint-disable-next-line consistent-return
-      runCompilerTest(expected, done, () => {
-        try {
-          transform(requiredStyle);
-        } catch (error) {
-          return error.message;
-        }
-      });
-    });
-
-    it('es6 export: should not throw any error', (done) => {
-      // eslint-disable-next-line global-require
-      const transform = require('./transforms/transform_es6');
-
-      styleLoaderOptions.transform = 'test/transforms/transform_es6';
-
-      const expectedTansformedStyle = transform[Object.keys(transform)[0]](
-        requiredStyle
-      );
-      const expected = [existingStyle, expectedTansformedStyle].join('\n');
-
-      runCompilerTest(expected, done);
-    });
-  });
-
   describe('HMR', () => {
     it('should output HMR code block by default', (done) => {
       setupWebpackConfig({

--- a/test/runtime/__snapshots__/addStyle.test.js.snap
+++ b/test/runtime/__snapshots__/addStyle.test.js.snap
@@ -52,12 +52,6 @@ exports[`addStyle should work with "sourceMap" option #3 1`] = `"<head><title>Ti
 
 exports[`addStyle should work with "sourceMap" option 1`] = `"<head><title>Title</title><style type=\\"text/css\\">.foo { color: red }</style></head><body><h1>Hello world</h1></body>"`;
 
-exports[`addStyle should work with "transform" option #2 1`] = `"<head><title>Title</title><style type=\\"text/css\\">.foo { color: yellow }</style></head><body><h1>Hello world</h1></body>"`;
-
-exports[`addStyle should work with "transform" option #3 1`] = `"<head><title>Title</title></head><body><h1>Hello world</h1></body>"`;
-
-exports[`addStyle should work with "transform" option 1`] = `"<head><title>Title</title><style type=\\"text/css\\">.foo { color: yellow }</style></head><body><h1>Hello world</h1></body>"`;
-
 exports[`addStyle should work with media 1`] = `"<head><title>Title</title><style type=\\"text/css\\" media=\\"screen and (min-width:320px)\\">.foo { color: red }</style></head><body><h1>Hello world</h1></body>"`;
 
 exports[`addStyle should work with nonce 1`] = `"<head><title>Title</title><style type=\\"text/css\\" nonce=\\"none\\">.foo { color: red }</style></head><body><h1>Hello world</h1></body>"`;

--- a/test/runtime/addStyle.test.js
+++ b/test/runtime/addStyle.test.js
@@ -586,36 +586,4 @@ describe('addStyle', () => {
       })
     ).toThrowErrorMatchingSnapshot();
   });
-
-  it('should work with "transform" option', () => {
-    addStyle([['./style-34.css', '.foo { color: red }', '']], {
-      transform: (css) => {
-        return css.replace('red', 'yellow');
-      },
-    });
-
-    expect(document.documentElement.innerHTML).toMatchSnapshot();
-  });
-
-  it('should work with "transform" option #2', () => {
-    addStyle([['./style-35.css', '.foo { color: red }', '']], {
-      transform: {
-        default: (css) => {
-          return css.replace('red', 'yellow');
-        },
-      },
-    });
-
-    expect(document.documentElement.innerHTML).toMatchSnapshot();
-  });
-
-  it('should work with "transform" option #3', () => {
-    addStyle([['./style-36.css', '.foo { color: red }', '']], {
-      transform: () => {
-        return false;
-      },
-    });
-
-    expect(document.documentElement.innerHTML).toMatchSnapshot();
-  });
 });

--- a/test/transforms/false.js
+++ b/test/transforms/false.js
@@ -1,1 +1,0 @@
-module.exports = () => false;

--- a/test/transforms/noop.js
+++ b/test/transforms/noop.js
@@ -1,1 +1,0 @@
-module.exports = () => {};

--- a/test/transforms/transform.js
+++ b/test/transforms/transform.js
@@ -1,1 +1,0 @@
-module.exports = (css) => css.replace('.required', '.transformed');

--- a/test/transforms/transform_es6.js
+++ b/test/transforms/transform_es6.js
@@ -1,1 +1,0 @@
-exports.default = (css) => css.replace('.required', '.transformed');

--- a/test/validate-options.test.js
+++ b/test/validate-options.test.js
@@ -31,9 +31,6 @@ it('validate options', () => {
   expect(() => validate({ attributes: { id: 'id' } })).not.toThrow();
   expect(() => validate({ attributes: true })).toThrowErrorMatchingSnapshot();
 
-  expect(() => validate({ transform: 'path/to/transform.js' })).not.toThrow();
-  expect(() => validate({ transform: true })).toThrowErrorMatchingSnapshot();
-
   expect(() => validate({ insertAt: 'top' })).not.toThrow();
   expect(() =>
     validate({


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Remove `transform` option because this option is unsafe (may create security bugs) and increase bundle size. We recommend use `postcss-loader` to handle css (polyfilling, replacing values and etc) or create separate loader for non standard things.

### Breaking Changes

Yes

BREAKING CHANGE: option `transform` was removed without replacement

### Additional Info

No