### PR TITLE
docs: example for `nonce` usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -574,6 +574,108 @@ module.exports = {
 };
 ```
 
+### Nonce
+
+There are two ways to work with `nonce`:
+
+- using the `attirbutes` option
+- using the `__webpack_nonce__` variable
+
+> ⚠ the `__webpack_nonce__` variable takes precedence over the `attibutes` option, so if define the `__webpack_nonce__` variable the `attributes` option will not be used
+
+### `attirbutes`
+
+**component.js**
+
+```js
+import './style.css';
+```
+
+**webpack.config.js**
+
+```js
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.css$/i,
+        use: [
+          {
+            loader: 'style-loader',
+            options: {
+              attributes: {
+                nonce: '12345678',
+              },
+            },
+          },
+          'css-loader',
+        ],
+      },
+    ],
+  },
+};
+```
+
+The loader generate:
+
+```html
+<style nonce="12345678">
+  .foo {
+    color: red;
+  }
+</style>
+```
+
+### `webpack_nonce`
+
+**create-nonce.js**
+
+```js
+__webpack_nonce__ = '12345678';
+```
+
+**component.js**
+
+```js
+import './create-nonce.js';
+import './style.css';
+```
+
+Alternative example for `require`:
+
+**component.js**
+
+```js
+__webpack_nonce__ = '12345678';
+
+require('./style.css');
+```
+
+**webpack.config.js**
+
+```js
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.css$/i,
+        use: ['style-loader', 'css-loader'],
+      },
+    ],
+  },
+};
+```
+
+The loader generate:
+
+```html
+<style nonce="12345678">
+  .foo {
+    color: red;
+  }
+</style>
+```
+
 ## Contributing
 
 Please take a moment to read our contributing guidelines if you haven't yet done so.


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [x] **metadata update**

### Motivation / Use-Case

example for `nonce`

### Breaking Changes

No

### Additional Info

fixes #306