### PR TITLE
fix: restore original hot reloading behaviour for locals

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -132,39 +132,23 @@ ${hmrCode}
       const hmrCode = this.hot
         ? `
 if (module.hot) {
-  module.hot.accept(
-    ${loaderUtils.stringifyRequest(this, `!!${request}`)},
-    function() {
-      var newContent = require(${loaderUtils.stringifyRequest(
-        this,
-        `!!${request}`
-      )});
+  if (!content.locals) {
+    module.hot.accept(
+      ${loaderUtils.stringifyRequest(this, `!!${request}`)},
+      function () {
+        var newContent = require(${loaderUtils.stringifyRequest(
+          this,
+          `!!${request}`
+        )});
 
-      if (typeof newContent === 'string') {
-        newContent = [[module.id, newContent, '']];
-      }
-
-      var locals = (function(a, b) {
-        var key,
-          idx = 0;
-
-        for (key in a) {
-          if(!b || a[key] !== b[key]) return false;
-          idx++;
+        if (typeof newContent === 'string') {
+          newContent = [[module.id, newContent, '']];
         }
-
-        for (key in b) idx--;
-
-        return idx === 0;
-      }(content.locals, newContent.locals));
-
-      if (!locals) {
-        throw new Error('Aborting CSS HMR due to changed css-modules locals.');
+        
+        update(newContent);
       }
-
-      update(newContent);
-    }
-  );
+    )
+  }
 
   module.hot.dispose(function() { 
     update();

--- a/test/manual/webpack.config.js
+++ b/test/manual/webpack.config.js
@@ -6,6 +6,7 @@ const ENABLE_SOURCE_MAP =
     : false;
 
 module.exports = {
+  devtool: ENABLE_SOURCE_MAP ? 'source-map' : false,
   mode: 'development',
   output: {
     publicPath: '/dist/',


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

fixes #320

### Breaking Changes

Yes

### Additional Info

/cc @lydell 

Here right example:
```js
if(module.hot.data) {
  if(!equal(module.hot.data.locals, locals)) {
    // Continue bubbling when we detect locals doesn't match
    module.hot.setUnhandled();
  }
}

module.hot.accept();
module.hot.dispose(data => {
  data.locals = locals;
});
```

but now we don't have `module.hot.setUnhandled` api, we will try implement this for `webpack@5` (but we have many tasks), now i jest revert this PR, because it is break hot reloading in many cases (include `hot-react-loader`)