### PR TITLE
Typo: attirbutes→attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,12 +577,12 @@ module.exports = {
 
 There are two ways to work with `nonce`:
 
-- using the `attirbutes` option
+- using the `attributes` option
 - using the `__webpack_nonce__` variable
 
-> ⚠ the `attibutes` option takes precedence over the `__webpack_nonce__` variable
+> ⚠ the `attributes` option takes precedence over the `__webpack_nonce__` variable
 
-#### `attirbutes`
+#### `attributes`
 
 **component.js**
 


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [x] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

“attributes” was misspelled a couple times. This also fixes the anchor fragment for linking to `#attributes`.

### Breaking Changes

I guess this would break existing URLs that pointed to `#attirbutes`.
