### PR TITLE
refactor: next

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,7 @@ Allows to setup how styles will be injected into the DOM.
 Possible values:
 
 - `styleTag`
-- `singletonStyleTag`
 - `lazyStyleTag`
-- `lazySingletonStyleTag`
 - `linkTag`
 
 #### `styleTag`
@@ -135,63 +133,6 @@ The loader inject styles like:
   }
 </style>
 <style>
-  .bar {
-    color: blue;
-  }
-</style>
-```
-
-#### `singletonStyleTag`
-
-Automatically injects styles into the DOM using one `<style></style>`.
-
-> ⚠ Source maps do not work.
-
-**component.js**
-
-```js
-import './styles.css';
-```
-
-**component-with-css-modules.js**
-
-```js
-import styles from './styles.css';
-
-const divElement = document.createElement('div');
-divElement.className = styles['my-class'];
-```
-
-All locals (class names) stored in imported object.
-
-**webpack.config.js**
-
-```js
-module.exports = {
-  module: {
-    rules: [
-      {
-        test: /\.css$/i,
-        use: [
-          {
-            loader: 'style-loader',
-            options: { injectType: 'singletonStyleTag' },
-          },
-          'css-loader',
-        ],
-      },
-    ],
-  },
-};
-```
-
-The loader inject styles like:
-
-```html
-<style>
-  .foo {
-    color: red;
-  }
   .bar {
     color: blue;
   }
@@ -261,75 +202,6 @@ The loader inject styles like:
   }
 </style>
 <style>
-  .bar {
-    color: blue;
-  }
-</style>
-```
-
-#### `lazySingletonStyleTag`
-
-Injects styles into the DOM using one `<style></style>` on demand.
-We recommend following `.lazy.css` naming convention for lazy styles and the `.css` for basic `style-loader` usage (similar to other file types, i.e. `.lazy.less` and `.less`).
-When you `lazySingletonStyleTag` value the `style-loader` injects the styles lazily making them useable on-demand via `style.use()` / `style.unuse()`.
-
-> ⚠️ Source maps do not work.
-
-> ⚠️ Behavior is undefined when `unuse` is called more often than `use`. Don't do that.
-
-**component.js**
-
-```js
-import styles from './styles.css';
-
-styles.use();
-// For removing styles you can use
-// styles.unuse();
-```
-
-**component-with-css-modules.js**
-
-```js
-import styles from './styles.lazy.css';
-
-styles.use();
-
-const divElement = document.createElement('div');
-divElement.className = styles.locals['my-class'];
-```
-
-All locals (class names) stored in `locals` property of imported object.
-
-**webpack.config.js**
-
-```js
-module.exports = {
-  module: {
-    rules: [
-      {
-        test: /\.css$/i,
-        exclude: /\.lazy\.css$/i,
-        use: ['style-loader', 'css-loader'],
-      },
-      {
-        test: /\.lazy\.css$/i,
-        use: [
-          { loader: 'style-loader', options: { injectType: 'lazyStyleTag' } },
-          'css-loader',
-        ],
-      },
-    ],
-  },
-};
-```
-
-The loader generate this:
-
-```html
-<style>
-  .foo {
-    color: red;
-  }
   .bar {
     color: blue;
   }

--- a/README.md
+++ b/README.md
@@ -424,12 +424,12 @@ module.exports = {
 ### `esModule`
 
 Type: `Boolean`
-Default: `false`
+Default: `true`
 
-By default, `style-loader` generates JS modules that use the CommonJS modules syntax.
+By default, `style-loader` generates JS modules that use the ES modules syntax.
 There are some cases in which using ES modules is beneficial, like in the case of [module concatenation](https://webpack.js.org/plugins/module-concatenation-plugin/) and [tree shaking](https://webpack.js.org/guides/tree-shaking/).
 
-You can enable a ES module syntax using:
+You can enable a CommonJS module syntax using:
 
 **webpack.config.js**
 
@@ -439,10 +439,15 @@ module.exports = {
     rules: [
       {
         test: /\.css$/i,
-        loader: 'css-loader',
-        options: {
-          esModule: true,
-        },
+        use: [
+          {
+            loader: 'style-loader',
+            options: {
+              esModule: false,
+            },
+          },
+          'css-loader',
+        ],
       },
     ],
   },

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,7 +41,7 @@ jobs:
     pool:
       vmImage: ubuntu-latest
     strategy:
-      maxParallel: 5
+      maxParallel: 4
       matrix:
         node-13:
           node_version: ^13.0.0
@@ -51,9 +51,6 @@ jobs:
           webpack_version: latest
         node-10:
           node_version: ^10.13.0
-          webpack_version: latest
-        node-8:
-          node_version: ^8.9.0
           webpack_version: latest
         node-10-canary:
           node_version: ^10.13.0
@@ -97,7 +94,7 @@ jobs:
     pool:
       vmImage: macOS-latest
     strategy:
-      maxParallel: 5
+      maxParallel: 4
       matrix:
         node-13:
           node_version: ^13.0.0
@@ -107,9 +104,6 @@ jobs:
           webpack_version: latest
         node-10:
           node_version: ^10.13.0
-          webpack_version: latest
-        node-8:
-          node_version: ^8.9.0
           webpack_version: latest
         node-10-canary:
           node_version: ^10.13.0
@@ -153,7 +147,7 @@ jobs:
     pool:
       vmImage: windows-latest
     strategy:
-      maxParallel: 5
+      maxParallel: 4
       matrix:
         node-13:
           node_version: ^13.0.0
@@ -163,9 +157,6 @@ jobs:
           webpack_version: latest
         node-10:
           node_version: ^10.13.0
-          webpack_version: latest
-        node-8:
-          node_version: ^8.9.0
           webpack_version: latest
         node-10-canary:
           node_version: ^10.13.0

--- a/babel.config.js
+++ b/babel.config.js
@@ -10,7 +10,7 @@ module.exports = (api) => {
         '@babel/preset-env',
         {
           targets: {
-            node: '8.9.0',
+            node: '10.13.0',
           },
         },
       ],

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "main": "dist/cjs.js",
   "engines": {
-    "node": ">= 8.9.0"
+    "node": ">= 10.13.0"
   },
   "scripts": {
     "start": "npm run build -- -w",

--- a/src/index.js
+++ b/src/index.js
@@ -89,10 +89,7 @@ ${hmrCode}
 ${esModule ? `export default {}` : ''}`;
     }
 
-    case 'lazyStyleTag':
-    case 'lazySingletonStyleTag': {
-      const isSingleton = injectType === 'lazySingletonStyleTag';
-
+    case 'lazyStyleTag': {
       const hmrCode = this.hot
         ? `
 if (module.hot) {
@@ -147,7 +144,6 @@ var dispose;
 var options = ${JSON.stringify(options)};
 
 options.insert = ${insert};
-options.singleton = ${isSingleton};
 
 var exported = {};
 
@@ -178,10 +174,7 @@ ${esModule ? 'export default' : 'module.exports ='} exported;`;
     }
 
     case 'styleTag':
-    case 'singletonStyleTag':
     default: {
-      const isSingleton = injectType === 'singletonStyleTag';
-
       const hmrCode = this.hot
         ? `
 if (module.hot) {
@@ -237,7 +230,6 @@ if (module.hot) {
 var options = ${JSON.stringify(options)};
 
 options.insert = ${insert};
-options.singleton = ${isSingleton};
 
 var id = ${loaderUtils.stringifyRequest(this, `!!${request}`)};
 var update = api(id, content, options);

--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,7 @@ loaderApi.pitch = function loader(request) {
       : options.insert.toString();
   const injectType = options.injectType || 'styleTag';
   const esModule =
-    typeof options.esModule !== 'undefined' ? options.esModule : false;
+    typeof options.esModule !== 'undefined' ? options.esModule : true;
 
   delete options.esModule;
 

--- a/src/index.js
+++ b/src/index.js
@@ -139,11 +139,7 @@ if (module.hot) {
               `!!${request}`
             )});
 
-            content = content.__esModule ? content.default : content;
-
-            if (typeof content === 'string') {
-              content = [[module.id, content, '']];
-            }`
+            content = content.__esModule ? content.default : content;`
       }
 
 var refs = 0;
@@ -203,10 +199,6 @@ if (module.hot) {
 
               newContent = newContent.__esModule ? newContent.default : newContent;
 
-              if (typeof newContent === 'string') {
-                newContent = [[module.id, newContent, '']];
-              }
-
               update(newContent);`
         }
       }
@@ -239,11 +231,7 @@ if (module.hot) {
               `!!${request}`
             )});
 
-            content = content.__esModule ? content.default : content;
-
-            if (typeof content === 'string') {
-              content = [[module.id, content, '']];
-            }`
+            content = content.__esModule ? content.default : content;`
       }
 
 var options = ${JSON.stringify(options)};

--- a/src/options.json
+++ b/src/options.json
@@ -3,13 +3,7 @@
   "properties": {
     "injectType": {
       "description": "Allows to setup how styles will be injected into DOM (https://github.com/webpack-contrib/style-loader#injecttype).",
-      "enum": [
-        "styleTag",
-        "singletonStyleTag",
-        "lazyStyleTag",
-        "lazySingletonStyleTag",
-        "linkTag"
-      ]
+      "enum": ["styleTag", "lazyStyleTag", "linkTag"]
     },
     "attributes": {
       "description": "Adds custom attributes to tag (https://github.com/webpack-contrib/style-loader#attributes).",

--- a/src/runtime/injectStylesIntoStyleTag.js
+++ b/src/runtime/injectStylesIntoStyleTag.js
@@ -59,7 +59,7 @@ function addModulesToDom(id, list, options) {
   }
 }
 
-function insertStyleElement(options) {
+function addStyle(obj, options) {
   const style = document.createElement('style');
   const attributes = options.attributes || {};
 
@@ -90,47 +90,36 @@ function insertStyleElement(options) {
     target.appendChild(style);
   }
 
-  return style;
-}
+  const update = (newObj) => {
+    let css = newObj.css;
+    const media = newObj.media;
+    const sourceMap = newObj.sourceMap;
 
-function removeStyleElement(style) {
-  // istanbul ignore if
-  if (style.parentNode === null) {
-    return false;
-  }
+    if (media) {
+      style.setAttribute('media', media);
+    } else {
+      style.removeAttribute('media');
+    }
 
-  style.parentNode.removeChild(style);
-}
+    if (sourceMap && btoa) {
+      css += `\n/*# sourceMappingURL=data:application/json;base64,${btoa(
+        unescape(encodeURIComponent(JSON.stringify(sourceMap)))
+      )} */`;
+    }
 
-function applyToTag(style, options, obj) {
-  let css = obj.css;
-  const media = obj.media;
-  const sourceMap = obj.sourceMap;
+    while (style.firstChild) {
+      style.removeChild(style.firstChild);
+    }
 
-  if (media) {
-    style.setAttribute('media', media);
-  } else {
-    style.removeAttribute('media');
-  }
-
-  if (sourceMap && btoa) {
-    css += `\n/*# sourceMappingURL=data:application/json;base64,${btoa(
-      unescape(encodeURIComponent(JSON.stringify(sourceMap)))
-    )} */`;
-  }
-
-  while (style.firstChild) {
-    style.removeChild(style.firstChild);
-  }
-
-  style.appendChild(document.createTextNode(css));
-}
-
-function addStyle(obj, options) {
-  const style = insertStyleElement(options);
-  const update = applyToTag.bind(null, style, options);
+    style.appendChild(document.createTextNode(css));
+  };
   const remove = () => {
-    removeStyleElement(style);
+    // istanbul ignore if
+    if (style.parentNode === null) {
+      return false;
+    }
+
+    style.parentNode.removeChild(style);
   };
 
   update(obj);

--- a/src/runtime/injectStylesIntoStyleTag.js
+++ b/src/runtime/injectStylesIntoStyleTag.js
@@ -119,17 +119,11 @@ function applyToTag(style, options, obj) {
     )} */`;
   }
 
-  // For old IE
-  /* istanbul ignore if  */
-  if (style.styleSheet) {
-    style.styleSheet.cssText = css;
-  } else {
-    while (style.firstChild) {
-      style.removeChild(style.firstChild);
-    }
-
-    style.appendChild(document.createTextNode(css));
+  while (style.firstChild) {
+    style.removeChild(style.firstChild);
   }
+
+  style.appendChild(document.createTextNode(css));
 }
 
 function addStyle(obj, options) {

--- a/test/__snapshots__/attributes-option.test.js.snap
+++ b/test/__snapshots__/attributes-option.test.js.snap
@@ -1,29 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`"attributes" option should add attributes to tag when the "injectType" option is "lazySingletonStyleTag": DOM 1`] = `
-"<!DOCTYPE html><html><head>
-  <title>style-loader test</title>
-  <style id=\\"existing-style\\">.existing { color: yellow }</style>
-<style type=\\"text/css\\" foo=\\"bar\\" data-id=\\"style-tag-id\\">body {
-  color: red;
-}
-h1 {
-  color: blue;
-}
-</style></head>
-<body>
-  <h1>Body</h1>
-  <div class=\\"target\\"></div>
-  <iframe class=\\"iframeTarget\\"></iframe>
-
-
-</body></html>"
-`;
-
-exports[`"attributes" option should add attributes to tag when the "injectType" option is "lazySingletonStyleTag": errors 1`] = `Array []`;
-
-exports[`"attributes" option should add attributes to tag when the "injectType" option is "lazySingletonStyleTag": warnings 1`] = `Array []`;
-
 exports[`"attributes" option should add attributes to tag when the "injectType" option is "lazyStyleTag": DOM 1`] = `
 "<!DOCTYPE html><html><head>
   <title>style-loader test</title>
@@ -66,30 +42,6 @@ exports[`"attributes" option should add attributes to tag when the "injectType" 
 
 exports[`"attributes" option should add attributes to tag when the "injectType" option is "linkTag": warnings 1`] = `Array []`;
 
-exports[`"attributes" option should add attributes to tag when the "injectType" option is "singletonStyleTag": DOM 1`] = `
-"<!DOCTYPE html><html><head>
-  <title>style-loader test</title>
-  <style id=\\"existing-style\\">.existing { color: yellow }</style>
-<style type=\\"text/css\\" foo=\\"bar\\" data-id=\\"style-tag-id\\">body {
-  color: red;
-}
-h1 {
-  color: blue;
-}
-</style></head>
-<body>
-  <h1>Body</h1>
-  <div class=\\"target\\"></div>
-  <iframe class=\\"iframeTarget\\"></iframe>
-
-
-</body></html>"
-`;
-
-exports[`"attributes" option should add attributes to tag when the "injectType" option is "singletonStyleTag": errors 1`] = `Array []`;
-
-exports[`"attributes" option should add attributes to tag when the "injectType" option is "singletonStyleTag": warnings 1`] = `Array []`;
-
 exports[`"attributes" option should add attributes to tag when the "injectType" option is "styleTag": DOM 1`] = `
 "<!DOCTYPE html><html><head>
   <title>style-loader test</title>
@@ -113,48 +65,6 @@ exports[`"attributes" option should add attributes to tag when the "injectType" 
 exports[`"attributes" option should add attributes to tag when the "injectType" option is "styleTag": errors 1`] = `Array []`;
 
 exports[`"attributes" option should add attributes to tag when the "injectType" option is "styleTag": warnings 1`] = `Array []`;
-
-exports[`"attributes" option should add nonce attribute when "injectType" option is "lazySingletonStyleTag" #2: DOM 1`] = `
-"<!DOCTYPE html><html><head>
-  <title>style-loader test</title>
-  <style id=\\"existing-style\\">.existing { color: yellow }</style>
-<style nonce=\\"12345678\\">body {
-  color: red;
-}
-</style></head>
-<body>
-  <h1>Body</h1>
-  <div class=\\"target\\"></div>
-  <iframe class=\\"iframeTarget\\"></iframe>
-
-
-</body></html>"
-`;
-
-exports[`"attributes" option should add nonce attribute when "injectType" option is "lazySingletonStyleTag" #2: errors 1`] = `Array []`;
-
-exports[`"attributes" option should add nonce attribute when "injectType" option is "lazySingletonStyleTag" #2: warnings 1`] = `Array []`;
-
-exports[`"attributes" option should add nonce attribute when "injectType" option is "lazySingletonStyleTag": DOM 1`] = `
-"<!DOCTYPE html><html><head>
-  <title>style-loader test</title>
-  <style id=\\"existing-style\\">.existing { color: yellow }</style>
-<style nonce=\\"12345678\\">body {
-  color: red;
-}
-</style></head>
-<body>
-  <h1>Body</h1>
-  <div class=\\"target\\"></div>
-  <iframe class=\\"iframeTarget\\"></iframe>
-
-
-</body></html>"
-`;
-
-exports[`"attributes" option should add nonce attribute when "injectType" option is "lazySingletonStyleTag": errors 1`] = `Array []`;
-
-exports[`"attributes" option should add nonce attribute when "injectType" option is "lazySingletonStyleTag": warnings 1`] = `Array []`;
 
 exports[`"attributes" option should add nonce attribute when "injectType" option is "lazyStyleTag" #2: DOM 1`] = `
 "<!DOCTYPE html><html><head>
@@ -233,48 +143,6 @@ exports[`"attributes" option should add nonce attribute when "injectType" option
 exports[`"attributes" option should add nonce attribute when "injectType" option is "linkTag": errors 1`] = `Array []`;
 
 exports[`"attributes" option should add nonce attribute when "injectType" option is "linkTag": warnings 1`] = `Array []`;
-
-exports[`"attributes" option should add nonce attribute when "injectType" option is "singletonStyleTag" #2: DOM 1`] = `
-"<!DOCTYPE html><html><head>
-  <title>style-loader test</title>
-  <style id=\\"existing-style\\">.existing { color: yellow }</style>
-<style nonce=\\"12345678\\">body {
-  color: red;
-}
-</style></head>
-<body>
-  <h1>Body</h1>
-  <div class=\\"target\\"></div>
-  <iframe class=\\"iframeTarget\\"></iframe>
-
-
-</body></html>"
-`;
-
-exports[`"attributes" option should add nonce attribute when "injectType" option is "singletonStyleTag" #2: errors 1`] = `Array []`;
-
-exports[`"attributes" option should add nonce attribute when "injectType" option is "singletonStyleTag" #2: warnings 1`] = `Array []`;
-
-exports[`"attributes" option should add nonce attribute when "injectType" option is "singletonStyleTag": DOM 1`] = `
-"<!DOCTYPE html><html><head>
-  <title>style-loader test</title>
-  <style id=\\"existing-style\\">.existing { color: yellow }</style>
-<style nonce=\\"12345678\\">body {
-  color: red;
-}
-</style></head>
-<body>
-  <h1>Body</h1>
-  <div class=\\"target\\"></div>
-  <iframe class=\\"iframeTarget\\"></iframe>
-
-
-</body></html>"
-`;
-
-exports[`"attributes" option should add nonce attribute when "injectType" option is "singletonStyleTag": errors 1`] = `Array []`;
-
-exports[`"attributes" option should add nonce attribute when "injectType" option is "singletonStyleTag": warnings 1`] = `Array []`;
 
 exports[`"attributes" option should add nonce attribute when "injectType" option is "styleTag" #2: DOM 1`] = `
 "<!DOCTYPE html><html><head>

--- a/test/__snapshots__/esModule-option.test.js.snap
+++ b/test/__snapshots__/esModule-option.test.js.snap
@@ -1,29 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`"esModule" option should work when not specified and when the "injectType" option is "lazySingletonStyleTag": DOM 1`] = `
-"<!DOCTYPE html><html><head>
-  <title>style-loader test</title>
-  <style id=\\"existing-style\\">.existing { color: yellow }</style>
-<style>body {
-  color: red;
-}
-h1 {
-  color: blue;
-}
-</style></head>
-<body>
-  <h1>Body</h1>
-  <div class=\\"target\\"></div>
-  <iframe class=\\"iframeTarget\\"></iframe>
-
-
-</body></html>"
-`;
-
-exports[`"esModule" option should work when not specified and when the "injectType" option is "lazySingletonStyleTag": errors 1`] = `Array []`;
-
-exports[`"esModule" option should work when not specified and when the "injectType" option is "lazySingletonStyleTag": warnings 1`] = `Array []`;
-
 exports[`"esModule" option should work when not specified and when the "injectType" option is "lazyStyleTag": DOM 1`] = `
 "<!DOCTYPE html><html><head>
   <title>style-loader test</title>
@@ -66,30 +42,6 @@ exports[`"esModule" option should work when not specified and when the "injectTy
 
 exports[`"esModule" option should work when not specified and when the "injectType" option is "linkTag": warnings 1`] = `Array []`;
 
-exports[`"esModule" option should work when not specified and when the "injectType" option is "singletonStyleTag": DOM 1`] = `
-"<!DOCTYPE html><html><head>
-  <title>style-loader test</title>
-  <style id=\\"existing-style\\">.existing { color: yellow }</style>
-<style>body {
-  color: red;
-}
-h1 {
-  color: blue;
-}
-</style></head>
-<body>
-  <h1>Body</h1>
-  <div class=\\"target\\"></div>
-  <iframe class=\\"iframeTarget\\"></iframe>
-
-
-</body></html>"
-`;
-
-exports[`"esModule" option should work when not specified and when the "injectType" option is "singletonStyleTag": errors 1`] = `Array []`;
-
-exports[`"esModule" option should work when not specified and when the "injectType" option is "singletonStyleTag": warnings 1`] = `Array []`;
-
 exports[`"esModule" option should work when not specified and when the "injectType" option is "styleTag": DOM 1`] = `
 "<!DOCTYPE html><html><head>
   <title>style-loader test</title>
@@ -113,78 +65,6 @@ exports[`"esModule" option should work when not specified and when the "injectTy
 exports[`"esModule" option should work when not specified and when the "injectType" option is "styleTag": errors 1`] = `Array []`;
 
 exports[`"esModule" option should work when not specified and when the "injectType" option is "styleTag": warnings 1`] = `Array []`;
-
-exports[`"esModule" option should work with a value equal to "false" and when the "injectType" option is "lazySingletonStyleTag" and CommonJS module syntax used: DOM 1`] = `
-"<!DOCTYPE html><html><head>
-  <title>style-loader test</title>
-  <style id=\\"existing-style\\">.existing { color: yellow }</style>
-<style>body {
-  color: red;
-}
-h1 {
-  color: blue;
-}
-</style></head>
-<body>
-  <h1>Body</h1>
-  <div class=\\"target\\"></div>
-  <iframe class=\\"iframeTarget\\"></iframe>
-
-
-</body></html>"
-`;
-
-exports[`"esModule" option should work with a value equal to "false" and when the "injectType" option is "lazySingletonStyleTag" and CommonJS module syntax used: errors 1`] = `Array []`;
-
-exports[`"esModule" option should work with a value equal to "false" and when the "injectType" option is "lazySingletonStyleTag" and CommonJS module syntax used: warnings 1`] = `Array []`;
-
-exports[`"esModule" option should work with a value equal to "false" and when the "injectType" option is "lazySingletonStyleTag" and ES module syntax used: DOM 1`] = `
-"<!DOCTYPE html><html><head>
-  <title>style-loader test</title>
-  <style id=\\"existing-style\\">.existing { color: yellow }</style>
-<style>body {
-  color: red;
-}
-h1 {
-  color: blue;
-}
-</style></head>
-<body>
-  <h1>Body</h1>
-  <div class=\\"target\\"></div>
-  <iframe class=\\"iframeTarget\\"></iframe>
-
-
-</body></html>"
-`;
-
-exports[`"esModule" option should work with a value equal to "false" and when the "injectType" option is "lazySingletonStyleTag" and ES module syntax used: errors 1`] = `Array []`;
-
-exports[`"esModule" option should work with a value equal to "false" and when the "injectType" option is "lazySingletonStyleTag" and ES module syntax used: warnings 1`] = `Array []`;
-
-exports[`"esModule" option should work with a value equal to "false" and when the "injectType" option is "lazySingletonStyleTag": DOM 1`] = `
-"<!DOCTYPE html><html><head>
-  <title>style-loader test</title>
-  <style id=\\"existing-style\\">.existing { color: yellow }</style>
-<style>body {
-  color: red;
-}
-h1 {
-  color: blue;
-}
-</style></head>
-<body>
-  <h1>Body</h1>
-  <div class=\\"target\\"></div>
-  <iframe class=\\"iframeTarget\\"></iframe>
-
-
-</body></html>"
-`;
-
-exports[`"esModule" option should work with a value equal to "false" and when the "injectType" option is "lazySingletonStyleTag": errors 1`] = `Array []`;
-
-exports[`"esModule" option should work with a value equal to "false" and when the "injectType" option is "lazySingletonStyleTag": warnings 1`] = `Array []`;
 
 exports[`"esModule" option should work with a value equal to "false" and when the "injectType" option is "lazyStyleTag" and CommonJS module syntax used: DOM 1`] = `
 "<!DOCTYPE html><html><head>
@@ -312,78 +192,6 @@ exports[`"esModule" option should work with a value equal to "false" and when th
 
 exports[`"esModule" option should work with a value equal to "false" and when the "injectType" option is "linkTag": warnings 1`] = `Array []`;
 
-exports[`"esModule" option should work with a value equal to "false" and when the "injectType" option is "singletonStyleTag" and CommonJS module syntax used: DOM 1`] = `
-"<!DOCTYPE html><html><head>
-  <title>style-loader test</title>
-  <style id=\\"existing-style\\">.existing { color: yellow }</style>
-<style>body {
-  color: red;
-}
-h1 {
-  color: blue;
-}
-</style></head>
-<body>
-  <h1>Body</h1>
-  <div class=\\"target\\"></div>
-  <iframe class=\\"iframeTarget\\"></iframe>
-
-
-</body></html>"
-`;
-
-exports[`"esModule" option should work with a value equal to "false" and when the "injectType" option is "singletonStyleTag" and CommonJS module syntax used: errors 1`] = `Array []`;
-
-exports[`"esModule" option should work with a value equal to "false" and when the "injectType" option is "singletonStyleTag" and CommonJS module syntax used: warnings 1`] = `Array []`;
-
-exports[`"esModule" option should work with a value equal to "false" and when the "injectType" option is "singletonStyleTag" and ES module syntax used: DOM 1`] = `
-"<!DOCTYPE html><html><head>
-  <title>style-loader test</title>
-  <style id=\\"existing-style\\">.existing { color: yellow }</style>
-<style>body {
-  color: red;
-}
-h1 {
-  color: blue;
-}
-</style></head>
-<body>
-  <h1>Body</h1>
-  <div class=\\"target\\"></div>
-  <iframe class=\\"iframeTarget\\"></iframe>
-
-
-</body></html>"
-`;
-
-exports[`"esModule" option should work with a value equal to "false" and when the "injectType" option is "singletonStyleTag" and ES module syntax used: errors 1`] = `Array []`;
-
-exports[`"esModule" option should work with a value equal to "false" and when the "injectType" option is "singletonStyleTag" and ES module syntax used: warnings 1`] = `Array []`;
-
-exports[`"esModule" option should work with a value equal to "false" and when the "injectType" option is "singletonStyleTag": DOM 1`] = `
-"<!DOCTYPE html><html><head>
-  <title>style-loader test</title>
-  <style id=\\"existing-style\\">.existing { color: yellow }</style>
-<style>body {
-  color: red;
-}
-h1 {
-  color: blue;
-}
-</style></head>
-<body>
-  <h1>Body</h1>
-  <div class=\\"target\\"></div>
-  <iframe class=\\"iframeTarget\\"></iframe>
-
-
-</body></html>"
-`;
-
-exports[`"esModule" option should work with a value equal to "false" and when the "injectType" option is "singletonStyleTag": errors 1`] = `Array []`;
-
-exports[`"esModule" option should work with a value equal to "false" and when the "injectType" option is "singletonStyleTag": warnings 1`] = `Array []`;
-
 exports[`"esModule" option should work with a value equal to "false" and when the "injectType" option is "styleTag" and CommonJS module syntax used: DOM 1`] = `
 "<!DOCTYPE html><html><head>
   <title>style-loader test</title>
@@ -455,78 +263,6 @@ exports[`"esModule" option should work with a value equal to "false" and when th
 exports[`"esModule" option should work with a value equal to "false" and when the "injectType" option is "styleTag": errors 1`] = `Array []`;
 
 exports[`"esModule" option should work with a value equal to "false" and when the "injectType" option is "styleTag": warnings 1`] = `Array []`;
-
-exports[`"esModule" option should work with a value equal to "true" and when the "injectType" option is "lazySingletonStyleTag" and CommonJS module syntax used: DOM 1`] = `
-"<!DOCTYPE html><html><head>
-  <title>style-loader test</title>
-  <style id=\\"existing-style\\">.existing { color: yellow }</style>
-<style>body {
-  color: red;
-}
-h1 {
-  color: blue;
-}
-</style></head>
-<body>
-  <h1>Body</h1>
-  <div class=\\"target\\"></div>
-  <iframe class=\\"iframeTarget\\"></iframe>
-
-
-</body></html>"
-`;
-
-exports[`"esModule" option should work with a value equal to "true" and when the "injectType" option is "lazySingletonStyleTag" and CommonJS module syntax used: errors 1`] = `Array []`;
-
-exports[`"esModule" option should work with a value equal to "true" and when the "injectType" option is "lazySingletonStyleTag" and CommonJS module syntax used: warnings 1`] = `Array []`;
-
-exports[`"esModule" option should work with a value equal to "true" and when the "injectType" option is "lazySingletonStyleTag" and ES module syntax used: DOM 1`] = `
-"<!DOCTYPE html><html><head>
-  <title>style-loader test</title>
-  <style id=\\"existing-style\\">.existing { color: yellow }</style>
-<style>body {
-  color: red;
-}
-h1 {
-  color: blue;
-}
-</style></head>
-<body>
-  <h1>Body</h1>
-  <div class=\\"target\\"></div>
-  <iframe class=\\"iframeTarget\\"></iframe>
-
-
-</body></html>"
-`;
-
-exports[`"esModule" option should work with a value equal to "true" and when the "injectType" option is "lazySingletonStyleTag" and ES module syntax used: errors 1`] = `Array []`;
-
-exports[`"esModule" option should work with a value equal to "true" and when the "injectType" option is "lazySingletonStyleTag" and ES module syntax used: warnings 1`] = `Array []`;
-
-exports[`"esModule" option should work with a value equal to "true" and when the "injectType" option is "lazySingletonStyleTag": DOM 1`] = `
-"<!DOCTYPE html><html><head>
-  <title>style-loader test</title>
-  <style id=\\"existing-style\\">.existing { color: yellow }</style>
-<style>body {
-  color: red;
-}
-h1 {
-  color: blue;
-}
-</style></head>
-<body>
-  <h1>Body</h1>
-  <div class=\\"target\\"></div>
-  <iframe class=\\"iframeTarget\\"></iframe>
-
-
-</body></html>"
-`;
-
-exports[`"esModule" option should work with a value equal to "true" and when the "injectType" option is "lazySingletonStyleTag": errors 1`] = `Array []`;
-
-exports[`"esModule" option should work with a value equal to "true" and when the "injectType" option is "lazySingletonStyleTag": warnings 1`] = `Array []`;
 
 exports[`"esModule" option should work with a value equal to "true" and when the "injectType" option is "lazyStyleTag" and CommonJS module syntax used: DOM 1`] = `
 "<!DOCTYPE html><html><head>
@@ -653,78 +389,6 @@ exports[`"esModule" option should work with a value equal to "true" and when the
 exports[`"esModule" option should work with a value equal to "true" and when the "injectType" option is "linkTag": errors 1`] = `Array []`;
 
 exports[`"esModule" option should work with a value equal to "true" and when the "injectType" option is "linkTag": warnings 1`] = `Array []`;
-
-exports[`"esModule" option should work with a value equal to "true" and when the "injectType" option is "singletonStyleTag" and CommonJS module syntax used: DOM 1`] = `
-"<!DOCTYPE html><html><head>
-  <title>style-loader test</title>
-  <style id=\\"existing-style\\">.existing { color: yellow }</style>
-<style>body {
-  color: red;
-}
-h1 {
-  color: blue;
-}
-</style></head>
-<body>
-  <h1>Body</h1>
-  <div class=\\"target\\"></div>
-  <iframe class=\\"iframeTarget\\"></iframe>
-
-
-</body></html>"
-`;
-
-exports[`"esModule" option should work with a value equal to "true" and when the "injectType" option is "singletonStyleTag" and CommonJS module syntax used: errors 1`] = `Array []`;
-
-exports[`"esModule" option should work with a value equal to "true" and when the "injectType" option is "singletonStyleTag" and CommonJS module syntax used: warnings 1`] = `Array []`;
-
-exports[`"esModule" option should work with a value equal to "true" and when the "injectType" option is "singletonStyleTag" and ES module syntax used: DOM 1`] = `
-"<!DOCTYPE html><html><head>
-  <title>style-loader test</title>
-  <style id=\\"existing-style\\">.existing { color: yellow }</style>
-<style>body {
-  color: red;
-}
-h1 {
-  color: blue;
-}
-</style></head>
-<body>
-  <h1>Body</h1>
-  <div class=\\"target\\"></div>
-  <iframe class=\\"iframeTarget\\"></iframe>
-
-
-</body></html>"
-`;
-
-exports[`"esModule" option should work with a value equal to "true" and when the "injectType" option is "singletonStyleTag" and ES module syntax used: errors 1`] = `Array []`;
-
-exports[`"esModule" option should work with a value equal to "true" and when the "injectType" option is "singletonStyleTag" and ES module syntax used: warnings 1`] = `Array []`;
-
-exports[`"esModule" option should work with a value equal to "true" and when the "injectType" option is "singletonStyleTag": DOM 1`] = `
-"<!DOCTYPE html><html><head>
-  <title>style-loader test</title>
-  <style id=\\"existing-style\\">.existing { color: yellow }</style>
-<style>body {
-  color: red;
-}
-h1 {
-  color: blue;
-}
-</style></head>
-<body>
-  <h1>Body</h1>
-  <div class=\\"target\\"></div>
-  <iframe class=\\"iframeTarget\\"></iframe>
-
-
-</body></html>"
-`;
-
-exports[`"esModule" option should work with a value equal to "true" and when the "injectType" option is "singletonStyleTag": errors 1`] = `Array []`;
-
-exports[`"esModule" option should work with a value equal to "true" and when the "injectType" option is "singletonStyleTag": warnings 1`] = `Array []`;
 
 exports[`"esModule" option should work with a value equal to "true" and when the "injectType" option is "styleTag" and CommonJS module syntax used: DOM 1`] = `
 "<!DOCTYPE html><html><head>

--- a/test/__snapshots__/injectType-option.test.js.snap
+++ b/test/__snapshots__/injectType-option.test.js.snap
@@ -1,29 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`"injectType" option should work when the "injectType" option is "lazySingletonStyleTag": DOM 1`] = `
-"<!DOCTYPE html><html><head>
-  <title>style-loader test</title>
-  <style id=\\"existing-style\\">.existing { color: yellow }</style>
-<style>body {
-  color: red;
-}
-h1 {
-  color: blue;
-}
-</style></head>
-<body>
-  <h1>Body</h1>
-  <div class=\\"target\\"></div>
-  <iframe class=\\"iframeTarget\\"></iframe>
-
-
-</body></html>"
-`;
-
-exports[`"injectType" option should work when the "injectType" option is "lazySingletonStyleTag": errors 1`] = `Array []`;
-
-exports[`"injectType" option should work when the "injectType" option is "lazySingletonStyleTag": warnings 1`] = `Array []`;
-
 exports[`"injectType" option should work when the "injectType" option is "lazyStyleTag": DOM 1`] = `
 "<!DOCTYPE html><html><head>
   <title>style-loader test</title>
@@ -65,30 +41,6 @@ exports[`"injectType" option should work when the "injectType" option is "linkTa
 exports[`"injectType" option should work when the "injectType" option is "linkTag": errors 1`] = `Array []`;
 
 exports[`"injectType" option should work when the "injectType" option is "linkTag": warnings 1`] = `Array []`;
-
-exports[`"injectType" option should work when the "injectType" option is "singletonStyleTag": DOM 1`] = `
-"<!DOCTYPE html><html><head>
-  <title>style-loader test</title>
-  <style id=\\"existing-style\\">.existing { color: yellow }</style>
-<style>body {
-  color: red;
-}
-h1 {
-  color: blue;
-}
-</style></head>
-<body>
-  <h1>Body</h1>
-  <div class=\\"target\\"></div>
-  <iframe class=\\"iframeTarget\\"></iframe>
-
-
-</body></html>"
-`;
-
-exports[`"injectType" option should work when the "injectType" option is "singletonStyleTag": errors 1`] = `Array []`;
-
-exports[`"injectType" option should work when the "injectType" option is "singletonStyleTag": warnings 1`] = `Array []`;
 
 exports[`"injectType" option should work when the "injectType" option is "styleTag": DOM 1`] = `
 "<!DOCTYPE html><html><head>

--- a/test/__snapshots__/insert-option.test.js.snap
+++ b/test/__snapshots__/insert-option.test.js.snap
@@ -1,29 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`"insert" option should insert styles into "body" bottom when the "injectType" option is "lazySingletonStyleTag": DOM 1`] = `
-"<!DOCTYPE html><html><head>
-  <title>style-loader test</title>
-  <style id=\\"existing-style\\">.existing { color: yellow }</style>
-</head>
-<body>
-  <h1>Body</h1>
-  <div class=\\"target\\"></div>
-  <iframe class=\\"iframeTarget\\"></iframe>
-
-
-<style>body {
-  color: red;
-}
-h1 {
-  color: blue;
-}
-</style></body></html>"
-`;
-
-exports[`"insert" option should insert styles into "body" bottom when the "injectType" option is "lazySingletonStyleTag": errors 1`] = `Array []`;
-
-exports[`"insert" option should insert styles into "body" bottom when the "injectType" option is "lazySingletonStyleTag": warnings 1`] = `Array []`;
-
 exports[`"insert" option should insert styles into "body" bottom when the "injectType" option is "lazyStyleTag": DOM 1`] = `
 "<!DOCTYPE html><html><head>
   <title>style-loader test</title>
@@ -66,30 +42,6 @@ exports[`"insert" option should insert styles into "body" bottom when the "injec
 
 exports[`"insert" option should insert styles into "body" bottom when the "injectType" option is "linkTag": warnings 1`] = `Array []`;
 
-exports[`"insert" option should insert styles into "body" bottom when the "injectType" option is "singletonStyleTag": DOM 1`] = `
-"<!DOCTYPE html><html><head>
-  <title>style-loader test</title>
-  <style id=\\"existing-style\\">.existing { color: yellow }</style>
-</head>
-<body>
-  <h1>Body</h1>
-  <div class=\\"target\\"></div>
-  <iframe class=\\"iframeTarget\\"></iframe>
-
-
-<style>body {
-  color: red;
-}
-h1 {
-  color: blue;
-}
-</style></body></html>"
-`;
-
-exports[`"insert" option should insert styles into "body" bottom when the "injectType" option is "singletonStyleTag": errors 1`] = `Array []`;
-
-exports[`"insert" option should insert styles into "body" bottom when the "injectType" option is "singletonStyleTag": warnings 1`] = `Array []`;
-
 exports[`"insert" option should insert styles into "body" bottom when the "injectType" option is "styleTag": DOM 1`] = `
 "<!DOCTYPE html><html><head>
   <title>style-loader test</title>
@@ -113,30 +65,6 @@ exports[`"insert" option should insert styles into "body" bottom when the "injec
 exports[`"insert" option should insert styles into "body" bottom when the "injectType" option is "styleTag": errors 1`] = `Array []`;
 
 exports[`"insert" option should insert styles into "body" bottom when the "injectType" option is "styleTag": warnings 1`] = `Array []`;
-
-exports[`"insert" option should insert styles into "div.target" bottom when the "injectType" option is "lazySingletonStyleTag": DOM 1`] = `
-"<!DOCTYPE html><html><head>
-  <title>style-loader test</title>
-  <style id=\\"existing-style\\">.existing { color: yellow }</style>
-</head>
-<body>
-  <h1>Body</h1>
-  <div class=\\"target\\"><style>body {
-  color: red;
-}
-h1 {
-  color: blue;
-}
-</style></div>
-  <iframe class=\\"iframeTarget\\"></iframe>
-
-
-</body></html>"
-`;
-
-exports[`"insert" option should insert styles into "div.target" bottom when the "injectType" option is "lazySingletonStyleTag": errors 1`] = `Array []`;
-
-exports[`"insert" option should insert styles into "div.target" bottom when the "injectType" option is "lazySingletonStyleTag": warnings 1`] = `Array []`;
 
 exports[`"insert" option should insert styles into "div.target" bottom when the "injectType" option is "lazyStyleTag": DOM 1`] = `
 "<!DOCTYPE html><html><head>
@@ -180,30 +108,6 @@ exports[`"insert" option should insert styles into "div.target" bottom when the 
 
 exports[`"insert" option should insert styles into "div.target" bottom when the "injectType" option is "linkTag": warnings 1`] = `Array []`;
 
-exports[`"insert" option should insert styles into "div.target" bottom when the "injectType" option is "singletonStyleTag": DOM 1`] = `
-"<!DOCTYPE html><html><head>
-  <title>style-loader test</title>
-  <style id=\\"existing-style\\">.existing { color: yellow }</style>
-</head>
-<body>
-  <h1>Body</h1>
-  <div class=\\"target\\"><style>body {
-  color: red;
-}
-h1 {
-  color: blue;
-}
-</style></div>
-  <iframe class=\\"iframeTarget\\"></iframe>
-
-
-</body></html>"
-`;
-
-exports[`"insert" option should insert styles into "div.target" bottom when the "injectType" option is "singletonStyleTag": errors 1`] = `Array []`;
-
-exports[`"insert" option should insert styles into "div.target" bottom when the "injectType" option is "singletonStyleTag": warnings 1`] = `Array []`;
-
 exports[`"insert" option should insert styles into "div.target" bottom when the "injectType" option is "styleTag": DOM 1`] = `
 "<!DOCTYPE html><html><head>
   <title>style-loader test</title>
@@ -227,30 +131,6 @@ exports[`"insert" option should insert styles into "div.target" bottom when the 
 exports[`"insert" option should insert styles into "div.target" bottom when the "injectType" option is "styleTag": errors 1`] = `Array []`;
 
 exports[`"insert" option should insert styles into "div.target" bottom when the "injectType" option is "styleTag": warnings 1`] = `Array []`;
-
-exports[`"insert" option should insert styles into "head" bottom when not specified and when the "injectType" option is "lazySingletonStyleTag": DOM 1`] = `
-"<!DOCTYPE html><html><head>
-  <title>style-loader test</title>
-  <style id=\\"existing-style\\">.existing { color: yellow }</style>
-<style>body {
-  color: red;
-}
-h1 {
-  color: blue;
-}
-</style></head>
-<body>
-  <h1>Body</h1>
-  <div class=\\"target\\"></div>
-  <iframe class=\\"iframeTarget\\"></iframe>
-
-
-</body></html>"
-`;
-
-exports[`"insert" option should insert styles into "head" bottom when not specified and when the "injectType" option is "lazySingletonStyleTag": errors 1`] = `Array []`;
-
-exports[`"insert" option should insert styles into "head" bottom when not specified and when the "injectType" option is "lazySingletonStyleTag": warnings 1`] = `Array []`;
 
 exports[`"insert" option should insert styles into "head" bottom when not specified and when the "injectType" option is "lazyStyleTag": DOM 1`] = `
 "<!DOCTYPE html><html><head>
@@ -294,30 +174,6 @@ exports[`"insert" option should insert styles into "head" bottom when not specif
 
 exports[`"insert" option should insert styles into "head" bottom when not specified and when the "injectType" option is "linkTag": warnings 1`] = `Array []`;
 
-exports[`"insert" option should insert styles into "head" bottom when not specified and when the "injectType" option is "singletonStyleTag": DOM 1`] = `
-"<!DOCTYPE html><html><head>
-  <title>style-loader test</title>
-  <style id=\\"existing-style\\">.existing { color: yellow }</style>
-<style>body {
-  color: red;
-}
-h1 {
-  color: blue;
-}
-</style></head>
-<body>
-  <h1>Body</h1>
-  <div class=\\"target\\"></div>
-  <iframe class=\\"iframeTarget\\"></iframe>
-
-
-</body></html>"
-`;
-
-exports[`"insert" option should insert styles into "head" bottom when not specified and when the "injectType" option is "singletonStyleTag": errors 1`] = `Array []`;
-
-exports[`"insert" option should insert styles into "head" bottom when not specified and when the "injectType" option is "singletonStyleTag": warnings 1`] = `Array []`;
-
 exports[`"insert" option should insert styles into "head" bottom when not specified and when the "injectType" option is "styleTag": DOM 1`] = `
 "<!DOCTYPE html><html><head>
   <title>style-loader test</title>
@@ -341,30 +197,6 @@ exports[`"insert" option should insert styles into "head" bottom when not specif
 exports[`"insert" option should insert styles into "head" bottom when not specified and when the "injectType" option is "styleTag": errors 1`] = `Array []`;
 
 exports[`"insert" option should insert styles into "head" bottom when not specified and when the "injectType" option is "styleTag": warnings 1`] = `Array []`;
-
-exports[`"insert" option should insert styles into "head" top when the "injectType" option is "lazySingletonStyleTag": DOM 1`] = `
-"<!DOCTYPE html><html><head><style>body {
-  color: red;
-}
-h1 {
-  color: blue;
-}
-</style>
-  <title>style-loader test</title>
-  <style id=\\"existing-style\\">.existing { color: yellow }</style>
-</head>
-<body>
-  <h1>Body</h1>
-  <div class=\\"target\\"></div>
-  <iframe class=\\"iframeTarget\\"></iframe>
-
-
-</body></html>"
-`;
-
-exports[`"insert" option should insert styles into "head" top when the "injectType" option is "lazySingletonStyleTag": errors 1`] = `Array []`;
-
-exports[`"insert" option should insert styles into "head" top when the "injectType" option is "lazySingletonStyleTag": warnings 1`] = `Array []`;
 
 exports[`"insert" option should insert styles into "head" top when the "injectType" option is "lazyStyleTag": DOM 1`] = `
 "<!DOCTYPE html><html><head><style>body {
@@ -408,30 +240,6 @@ exports[`"insert" option should insert styles into "head" top when the "injectTy
 
 exports[`"insert" option should insert styles into "head" top when the "injectType" option is "linkTag": warnings 1`] = `Array []`;
 
-exports[`"insert" option should insert styles into "head" top when the "injectType" option is "singletonStyleTag": DOM 1`] = `
-"<!DOCTYPE html><html><head><style>body {
-  color: red;
-}
-h1 {
-  color: blue;
-}
-</style>
-  <title>style-loader test</title>
-  <style id=\\"existing-style\\">.existing { color: yellow }</style>
-</head>
-<body>
-  <h1>Body</h1>
-  <div class=\\"target\\"></div>
-  <iframe class=\\"iframeTarget\\"></iframe>
-
-
-</body></html>"
-`;
-
-exports[`"insert" option should insert styles into "head" top when the "injectType" option is "singletonStyleTag": errors 1`] = `Array []`;
-
-exports[`"insert" option should insert styles into "head" top when the "injectType" option is "singletonStyleTag": warnings 1`] = `Array []`;
-
 exports[`"insert" option should insert styles into "head" top when the "injectType" option is "styleTag": DOM 1`] = `
 "<!DOCTYPE html><html><head><style>body {
   color: red;
@@ -455,34 +263,6 @@ exports[`"insert" option should insert styles into "head" top when the "injectTy
 exports[`"insert" option should insert styles into "head" top when the "injectType" option is "styleTag": errors 1`] = `Array []`;
 
 exports[`"insert" option should insert styles into "head" top when the "injectType" option is "styleTag": warnings 1`] = `Array []`;
-
-exports[`"insert" option should insert styles into "iframe.iframeTarget" bottom when the "injectType" option is "lazySingletonStyleTag": DOM 1`] = `
-"<!DOCTYPE html><html><head>
-  <title>style-loader test</title>
-  <style id=\\"existing-style\\">.existing { color: yellow }</style>
-</head>
-<body>
-  <h1>Body</h1>
-  <div class=\\"target\\"></div>
-  <iframe class=\\"iframeTarget\\"></iframe>
-
-
-</body></html>"
-`;
-
-exports[`"insert" option should insert styles into "iframe.iframeTarget" bottom when the "injectType" option is "lazySingletonStyleTag": errors 1`] = `Array []`;
-
-exports[`"insert" option should insert styles into "iframe.iframeTarget" bottom when the "injectType" option is "lazySingletonStyleTag": iframe head 1`] = `
-"<style>body {
-  color: red;
-}
-h1 {
-  color: blue;
-}
-</style>"
-`;
-
-exports[`"insert" option should insert styles into "iframe.iframeTarget" bottom when the "injectType" option is "lazySingletonStyleTag": warnings 1`] = `Array []`;
 
 exports[`"insert" option should insert styles into "iframe.iframeTarget" bottom when the "injectType" option is "lazyStyleTag": DOM 1`] = `
 "<!DOCTYPE html><html><head>
@@ -532,34 +312,6 @@ exports[`"insert" option should insert styles into "iframe.iframeTarget" bottom 
 
 exports[`"insert" option should insert styles into "iframe.iframeTarget" bottom when the "injectType" option is "linkTag": warnings 1`] = `Array []`;
 
-exports[`"insert" option should insert styles into "iframe.iframeTarget" bottom when the "injectType" option is "singletonStyleTag": DOM 1`] = `
-"<!DOCTYPE html><html><head>
-  <title>style-loader test</title>
-  <style id=\\"existing-style\\">.existing { color: yellow }</style>
-</head>
-<body>
-  <h1>Body</h1>
-  <div class=\\"target\\"></div>
-  <iframe class=\\"iframeTarget\\"></iframe>
-
-
-</body></html>"
-`;
-
-exports[`"insert" option should insert styles into "iframe.iframeTarget" bottom when the "injectType" option is "singletonStyleTag": errors 1`] = `Array []`;
-
-exports[`"insert" option should insert styles into "iframe.iframeTarget" bottom when the "injectType" option is "singletonStyleTag": iframe head 1`] = `
-"<style>body {
-  color: red;
-}
-h1 {
-  color: blue;
-}
-</style>"
-`;
-
-exports[`"insert" option should insert styles into "iframe.iframeTarget" bottom when the "injectType" option is "singletonStyleTag": warnings 1`] = `Array []`;
-
 exports[`"insert" option should insert styles into "iframe.iframeTarget" bottom when the "injectType" option is "styleTag": DOM 1`] = `
 "<!DOCTYPE html><html><head>
   <title>style-loader test</title>
@@ -587,30 +339,6 @@ exports[`"insert" option should insert styles into "iframe.iframeTarget" bottom 
 `;
 
 exports[`"insert" option should insert styles into "iframe.iframeTarget" bottom when the "injectType" option is "styleTag": warnings 1`] = `Array []`;
-
-exports[`"insert" option should insert styles into before "#existing-style" id when the "injectType" option is "lazySingletonStyleTag": DOM 1`] = `
-"<!DOCTYPE html><html><head>
-  <title>style-loader test</title>
-  <style>body {
-  color: red;
-}
-h1 {
-  color: blue;
-}
-</style><style id=\\"existing-style\\">.existing { color: yellow }</style>
-</head>
-<body>
-  <h1>Body</h1>
-  <div class=\\"target\\"></div>
-  <iframe class=\\"iframeTarget\\"></iframe>
-
-
-</body></html>"
-`;
-
-exports[`"insert" option should insert styles into before "#existing-style" id when the "injectType" option is "lazySingletonStyleTag": errors 1`] = `Array []`;
-
-exports[`"insert" option should insert styles into before "#existing-style" id when the "injectType" option is "lazySingletonStyleTag": warnings 1`] = `Array []`;
 
 exports[`"insert" option should insert styles into before "#existing-style" id when the "injectType" option is "lazyStyleTag": DOM 1`] = `
 "<!DOCTYPE html><html><head>
@@ -654,30 +382,6 @@ exports[`"insert" option should insert styles into before "#existing-style" id w
 
 exports[`"insert" option should insert styles into before "#existing-style" id when the "injectType" option is "linkTag": warnings 1`] = `Array []`;
 
-exports[`"insert" option should insert styles into before "#existing-style" id when the "injectType" option is "singletonStyleTag": DOM 1`] = `
-"<!DOCTYPE html><html><head>
-  <title>style-loader test</title>
-  <style>body {
-  color: red;
-}
-h1 {
-  color: blue;
-}
-</style><style id=\\"existing-style\\">.existing { color: yellow }</style>
-</head>
-<body>
-  <h1>Body</h1>
-  <div class=\\"target\\"></div>
-  <iframe class=\\"iframeTarget\\"></iframe>
-
-
-</body></html>"
-`;
-
-exports[`"insert" option should insert styles into before "#existing-style" id when the "injectType" option is "singletonStyleTag": errors 1`] = `Array []`;
-
-exports[`"insert" option should insert styles into before "#existing-style" id when the "injectType" option is "singletonStyleTag": warnings 1`] = `Array []`;
-
 exports[`"insert" option should insert styles into before "#existing-style" id when the "injectType" option is "styleTag": DOM 1`] = `
 "<!DOCTYPE html><html><head>
   <title>style-loader test</title>
@@ -701,30 +405,6 @@ exports[`"insert" option should insert styles into before "#existing-style" id w
 exports[`"insert" option should insert styles into before "#existing-style" id when the "injectType" option is "styleTag": errors 1`] = `Array []`;
 
 exports[`"insert" option should insert styles into before "#existing-style" id when the "injectType" option is "styleTag": warnings 1`] = `Array []`;
-
-exports[`"insert" option should insert styles into runtime created element bottom when the "injectType" option is "lazySingletonStyleTag": DOM 1`] = `
-"<!DOCTYPE html><html><head>
-  <title>style-loader test</title>
-  <style id=\\"existing-style\\">.existing { color: yellow }</style>
-</head>
-<body>
-  <h1>Body</h1>
-  <div class=\\"target\\"></div>
-  <iframe class=\\"iframeTarget\\"></iframe>
-
-
-<div id=\\"test-shadow\\"><style>body {
-  color: red;
-}
-h1 {
-  color: blue;
-}
-</style></div></body></html>"
-`;
-
-exports[`"insert" option should insert styles into runtime created element bottom when the "injectType" option is "lazySingletonStyleTag": errors 1`] = `Array []`;
-
-exports[`"insert" option should insert styles into runtime created element bottom when the "injectType" option is "lazySingletonStyleTag": warnings 1`] = `Array []`;
 
 exports[`"insert" option should insert styles into runtime created element bottom when the "injectType" option is "lazyStyleTag": DOM 1`] = `
 "<!DOCTYPE html><html><head>
@@ -767,30 +447,6 @@ exports[`"insert" option should insert styles into runtime created element botto
 exports[`"insert" option should insert styles into runtime created element bottom when the "injectType" option is "linkTag": errors 1`] = `Array []`;
 
 exports[`"insert" option should insert styles into runtime created element bottom when the "injectType" option is "linkTag": warnings 1`] = `Array []`;
-
-exports[`"insert" option should insert styles into runtime created element bottom when the "injectType" option is "singletonStyleTag": DOM 1`] = `
-"<!DOCTYPE html><html><head>
-  <title>style-loader test</title>
-  <style id=\\"existing-style\\">.existing { color: yellow }</style>
-</head>
-<body>
-  <h1>Body</h1>
-  <div class=\\"target\\"></div>
-  <iframe class=\\"iframeTarget\\"></iframe>
-
-
-<div id=\\"test-shadow\\"><style>body {
-  color: red;
-}
-h1 {
-  color: blue;
-}
-</style></div></body></html>"
-`;
-
-exports[`"insert" option should insert styles into runtime created element bottom when the "injectType" option is "singletonStyleTag": errors 1`] = `Array []`;
-
-exports[`"insert" option should insert styles into runtime created element bottom when the "injectType" option is "singletonStyleTag": warnings 1`] = `Array []`;
 
 exports[`"insert" option should insert styles into runtime created element bottom when the "injectType" option is "styleTag": DOM 1`] = `
 "<!DOCTYPE html><html><head>

--- a/test/__snapshots__/loader.test.js.snap
+++ b/test/__snapshots__/loader.test.js.snap
@@ -1,29 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`loader should generate source maps when previous loader emit them when the "injectType" option is "lazySingletonStyleTag": DOM 1`] = `
-"<!DOCTYPE html><html><head>
-  <title>style-loader test</title>
-  <style id=\\"existing-style\\">.existing { color: yellow }</style>
-<style>body {
-  color: red;
-}
-h1 {
-  color: blue;
-}
-</style></head>
-<body>
-  <h1>Body</h1>
-  <div class=\\"target\\"></div>
-  <iframe class=\\"iframeTarget\\"></iframe>
-
-
-</body></html>"
-`;
-
-exports[`loader should generate source maps when previous loader emit them when the "injectType" option is "lazySingletonStyleTag": errors 1`] = `Array []`;
-
-exports[`loader should generate source maps when previous loader emit them when the "injectType" option is "lazySingletonStyleTag": warnings 1`] = `Array []`;
-
 exports[`loader should generate source maps when previous loader emit them when the "injectType" option is "lazyStyleTag": DOM 1`] = `
 "<!DOCTYPE html><html><head>
   <title>style-loader test</title>
@@ -68,30 +44,6 @@ exports[`loader should generate source maps when previous loader emit them when 
 
 exports[`loader should generate source maps when previous loader emit them when the "injectType" option is "linkTag": warnings 1`] = `Array []`;
 
-exports[`loader should generate source maps when previous loader emit them when the "injectType" option is "singletonStyleTag": DOM 1`] = `
-"<!DOCTYPE html><html><head>
-  <title>style-loader test</title>
-  <style id=\\"existing-style\\">.existing { color: yellow }</style>
-<style>body {
-  color: red;
-}
-h1 {
-  color: blue;
-}
-</style></head>
-<body>
-  <h1>Body</h1>
-  <div class=\\"target\\"></div>
-  <iframe class=\\"iframeTarget\\"></iframe>
-
-
-</body></html>"
-`;
-
-exports[`loader should generate source maps when previous loader emit them when the "injectType" option is "singletonStyleTag": errors 1`] = `Array []`;
-
-exports[`loader should generate source maps when previous loader emit them when the "injectType" option is "singletonStyleTag": warnings 1`] = `Array []`;
-
 exports[`loader should generate source maps when previous loader emit them when the "injectType" option is "styleTag": DOM 1`] = `
 "<!DOCTYPE html><html><head>
   <title>style-loader test</title>
@@ -118,10 +70,6 @@ exports[`loader should generate source maps when previous loader emit them when 
 
 exports[`loader should generate source maps when previous loader emit them when the "injectType" option is "styleTag": warnings 1`] = `Array []`;
 
-exports[`loader should inject hmr code with HotModuleReplacementPlugin when the "injectType" option is "lazySingletonStyleTag": errors 1`] = `Array []`;
-
-exports[`loader should inject hmr code with HotModuleReplacementPlugin when the "injectType" option is "lazySingletonStyleTag": warnings 1`] = `Array []`;
-
 exports[`loader should inject hmr code with HotModuleReplacementPlugin when the "injectType" option is "lazyStyleTag": errors 1`] = `Array []`;
 
 exports[`loader should inject hmr code with HotModuleReplacementPlugin when the "injectType" option is "lazyStyleTag": warnings 1`] = `Array []`;
@@ -130,37 +78,9 @@ exports[`loader should inject hmr code with HotModuleReplacementPlugin when the 
 
 exports[`loader should inject hmr code with HotModuleReplacementPlugin when the "injectType" option is "linkTag": warnings 1`] = `Array []`;
 
-exports[`loader should inject hmr code with HotModuleReplacementPlugin when the "injectType" option is "singletonStyleTag": errors 1`] = `Array []`;
-
-exports[`loader should inject hmr code with HotModuleReplacementPlugin when the "injectType" option is "singletonStyleTag": warnings 1`] = `Array []`;
-
 exports[`loader should inject hmr code with HotModuleReplacementPlugin when the "injectType" option is "styleTag": errors 1`] = `Array []`;
 
 exports[`loader should inject hmr code with HotModuleReplacementPlugin when the "injectType" option is "styleTag": warnings 1`] = `Array []`;
-
-exports[`loader should not generate source maps when previous loader don't emit them when the "injectType" option is "lazySingletonStyleTag": DOM 1`] = `
-"<!DOCTYPE html><html><head>
-  <title>style-loader test</title>
-  <style id=\\"existing-style\\">.existing { color: yellow }</style>
-<style>body {
-  color: red;
-}
-h1 {
-  color: blue;
-}
-</style></head>
-<body>
-  <h1>Body</h1>
-  <div class=\\"target\\"></div>
-  <iframe class=\\"iframeTarget\\"></iframe>
-
-
-</body></html>"
-`;
-
-exports[`loader should not generate source maps when previous loader don't emit them when the "injectType" option is "lazySingletonStyleTag": errors 1`] = `Array []`;
-
-exports[`loader should not generate source maps when previous loader don't emit them when the "injectType" option is "lazySingletonStyleTag": warnings 1`] = `Array []`;
 
 exports[`loader should not generate source maps when previous loader don't emit them when the "injectType" option is "lazyStyleTag": DOM 1`] = `
 "<!DOCTYPE html><html><head>
@@ -204,30 +124,6 @@ exports[`loader should not generate source maps when previous loader don't emit 
 
 exports[`loader should not generate source maps when previous loader don't emit them when the "injectType" option is "linkTag": warnings 1`] = `Array []`;
 
-exports[`loader should not generate source maps when previous loader don't emit them when the "injectType" option is "singletonStyleTag": DOM 1`] = `
-"<!DOCTYPE html><html><head>
-  <title>style-loader test</title>
-  <style id=\\"existing-style\\">.existing { color: yellow }</style>
-<style>body {
-  color: red;
-}
-h1 {
-  color: blue;
-}
-</style></head>
-<body>
-  <h1>Body</h1>
-  <div class=\\"target\\"></div>
-  <iframe class=\\"iframeTarget\\"></iframe>
-
-
-</body></html>"
-`;
-
-exports[`loader should not generate source maps when previous loader don't emit them when the "injectType" option is "singletonStyleTag": errors 1`] = `Array []`;
-
-exports[`loader should not generate source maps when previous loader don't emit them when the "injectType" option is "singletonStyleTag": warnings 1`] = `Array []`;
-
 exports[`loader should not generate source maps when previous loader don't emit them when the "injectType" option is "styleTag": DOM 1`] = `
 "<!DOCTYPE html><html><head>
   <title>style-loader test</title>
@@ -252,10 +148,6 @@ exports[`loader should not generate source maps when previous loader don't emit 
 
 exports[`loader should not generate source maps when previous loader don't emit them when the "injectType" option is "styleTag": warnings 1`] = `Array []`;
 
-exports[`loader should not inject hmr code without HotModuleReplacementPlugin when the "injectType" option is "lazySingletonStyleTag": errors 1`] = `Array []`;
-
-exports[`loader should not inject hmr code without HotModuleReplacementPlugin when the "injectType" option is "lazySingletonStyleTag": warnings 1`] = `Array []`;
-
 exports[`loader should not inject hmr code without HotModuleReplacementPlugin when the "injectType" option is "lazyStyleTag": errors 1`] = `Array []`;
 
 exports[`loader should not inject hmr code without HotModuleReplacementPlugin when the "injectType" option is "lazyStyleTag": warnings 1`] = `Array []`;
@@ -264,34 +156,9 @@ exports[`loader should not inject hmr code without HotModuleReplacementPlugin wh
 
 exports[`loader should not inject hmr code without HotModuleReplacementPlugin when the "injectType" option is "linkTag": warnings 1`] = `Array []`;
 
-exports[`loader should not inject hmr code without HotModuleReplacementPlugin when the "injectType" option is "singletonStyleTag": errors 1`] = `Array []`;
-
-exports[`loader should not inject hmr code without HotModuleReplacementPlugin when the "injectType" option is "singletonStyleTag": warnings 1`] = `Array []`;
-
 exports[`loader should not inject hmr code without HotModuleReplacementPlugin when the "injectType" option is "styleTag": errors 1`] = `Array []`;
 
 exports[`loader should not inject hmr code without HotModuleReplacementPlugin when the "injectType" option is "styleTag": warnings 1`] = `Array []`;
-
-exports[`loader should work when ref is negative when the "injectType" option is "lazySingletonStyleTag": DOM 1`] = `
-"<!DOCTYPE html><html><head>
-  <title>style-loader test</title>
-  <style id=\\"existing-style\\">.existing { color: yellow }</style>
-<style>body {
-  color: red;
-}
-</style></head>
-<body>
-  <h1>Body</h1>
-  <div class=\\"target\\"></div>
-  <iframe class=\\"iframeTarget\\"></iframe>
-
-
-</body></html>"
-`;
-
-exports[`loader should work when ref is negative when the "injectType" option is "lazySingletonStyleTag": errors 1`] = `Array []`;
-
-exports[`loader should work when ref is negative when the "injectType" option is "lazySingletonStyleTag": warnings 1`] = `Array []`;
 
 exports[`loader should work when ref is negative when the "injectType" option is "lazyStyleTag": DOM 1`] = `
 "<!DOCTYPE html><html><head>
@@ -313,78 +180,6 @@ exports[`loader should work when ref is negative when the "injectType" option is
 exports[`loader should work when ref is negative when the "injectType" option is "lazyStyleTag": errors 1`] = `Array []`;
 
 exports[`loader should work when ref is negative when the "injectType" option is "lazyStyleTag": warnings 1`] = `Array []`;
-
-exports[`loader should work when the "injectType" option is "lazySingletonStyleTag" and CommonJS module syntax used: DOM 1`] = `
-"<!DOCTYPE html><html><head>
-  <title>style-loader test</title>
-  <style id=\\"existing-style\\">.existing { color: yellow }</style>
-<style>body {
-  color: red;
-}
-h1 {
-  color: blue;
-}
-</style></head>
-<body>
-  <h1>Body</h1>
-  <div class=\\"target\\"></div>
-  <iframe class=\\"iframeTarget\\"></iframe>
-
-
-</body></html>"
-`;
-
-exports[`loader should work when the "injectType" option is "lazySingletonStyleTag" and CommonJS module syntax used: errors 1`] = `Array []`;
-
-exports[`loader should work when the "injectType" option is "lazySingletonStyleTag" and CommonJS module syntax used: warnings 1`] = `Array []`;
-
-exports[`loader should work when the "injectType" option is "lazySingletonStyleTag" and ES module syntax used: DOM 1`] = `
-"<!DOCTYPE html><html><head>
-  <title>style-loader test</title>
-  <style id=\\"existing-style\\">.existing { color: yellow }</style>
-<style>body {
-  color: red;
-}
-h1 {
-  color: blue;
-}
-</style></head>
-<body>
-  <h1>Body</h1>
-  <div class=\\"target\\"></div>
-  <iframe class=\\"iframeTarget\\"></iframe>
-
-
-</body></html>"
-`;
-
-exports[`loader should work when the "injectType" option is "lazySingletonStyleTag" and ES module syntax used: errors 1`] = `Array []`;
-
-exports[`loader should work when the "injectType" option is "lazySingletonStyleTag" and ES module syntax used: warnings 1`] = `Array []`;
-
-exports[`loader should work when the "injectType" option is "lazySingletonStyleTag": DOM 1`] = `
-"<!DOCTYPE html><html><head>
-  <title>style-loader test</title>
-  <style id=\\"existing-style\\">.existing { color: yellow }</style>
-<style>body {
-  color: red;
-}
-h1 {
-  color: blue;
-}
-</style></head>
-<body>
-  <h1>Body</h1>
-  <div class=\\"target\\"></div>
-  <iframe class=\\"iframeTarget\\"></iframe>
-
-
-</body></html>"
-`;
-
-exports[`loader should work when the "injectType" option is "lazySingletonStyleTag": errors 1`] = `Array []`;
-
-exports[`loader should work when the "injectType" option is "lazySingletonStyleTag": warnings 1`] = `Array []`;
 
 exports[`loader should work when the "injectType" option is "lazyStyleTag" and CommonJS module syntax used: DOM 1`] = `
 "<!DOCTYPE html><html><head>
@@ -512,78 +307,6 @@ exports[`loader should work when the "injectType" option is "linkTag": errors 1`
 
 exports[`loader should work when the "injectType" option is "linkTag": warnings 1`] = `Array []`;
 
-exports[`loader should work when the "injectType" option is "singletonStyleTag" and CommonJS module syntax used: DOM 1`] = `
-"<!DOCTYPE html><html><head>
-  <title>style-loader test</title>
-  <style id=\\"existing-style\\">.existing { color: yellow }</style>
-<style>body {
-  color: red;
-}
-h1 {
-  color: blue;
-}
-</style></head>
-<body>
-  <h1>Body</h1>
-  <div class=\\"target\\"></div>
-  <iframe class=\\"iframeTarget\\"></iframe>
-
-
-</body></html>"
-`;
-
-exports[`loader should work when the "injectType" option is "singletonStyleTag" and CommonJS module syntax used: errors 1`] = `Array []`;
-
-exports[`loader should work when the "injectType" option is "singletonStyleTag" and CommonJS module syntax used: warnings 1`] = `Array []`;
-
-exports[`loader should work when the "injectType" option is "singletonStyleTag" and ES module syntax used: DOM 1`] = `
-"<!DOCTYPE html><html><head>
-  <title>style-loader test</title>
-  <style id=\\"existing-style\\">.existing { color: yellow }</style>
-<style>body {
-  color: red;
-}
-h1 {
-  color: blue;
-}
-</style></head>
-<body>
-  <h1>Body</h1>
-  <div class=\\"target\\"></div>
-  <iframe class=\\"iframeTarget\\"></iframe>
-
-
-</body></html>"
-`;
-
-exports[`loader should work when the "injectType" option is "singletonStyleTag" and ES module syntax used: errors 1`] = `Array []`;
-
-exports[`loader should work when the "injectType" option is "singletonStyleTag" and ES module syntax used: warnings 1`] = `Array []`;
-
-exports[`loader should work when the "injectType" option is "singletonStyleTag": DOM 1`] = `
-"<!DOCTYPE html><html><head>
-  <title>style-loader test</title>
-  <style id=\\"existing-style\\">.existing { color: yellow }</style>
-<style>body {
-  color: red;
-}
-h1 {
-  color: blue;
-}
-</style></head>
-<body>
-  <h1>Body</h1>
-  <div class=\\"target\\"></div>
-  <iframe class=\\"iframeTarget\\"></iframe>
-
-
-</body></html>"
-`;
-
-exports[`loader should work when the "injectType" option is "singletonStyleTag": errors 1`] = `Array []`;
-
-exports[`loader should work when the "injectType" option is "singletonStyleTag": warnings 1`] = `Array []`;
-
 exports[`loader should work when the "injectType" option is "styleTag" and CommonJS module syntax used: DOM 1`] = `
 "<!DOCTYPE html><html><head>
   <title>style-loader test</title>
@@ -656,34 +379,6 @@ exports[`loader should work when the "injectType" option is "styleTag": errors 1
 
 exports[`loader should work when the "injectType" option is "styleTag": warnings 1`] = `Array []`;
 
-exports[`loader should work with css modules when the "injectType" option is "lazySingletonStyleTag": DOM 1`] = `
-"<!DOCTYPE html><html><head>
-  <title>style-loader test</title>
-  <style id=\\"existing-style\\">.existing { color: yellow }</style>
-<style>.css-modules-local-scoped-className_2SS6AUo {
-  background: red;
-}
-.css-modules-myClassName_29qd4Wo {
-  background: red;
-}
-
-.css-modules-myComposingClass_EtB1JLd {
-  color: blue;
-}
-</style></head>
-<body>
-  <h1>Body</h1>
-  <div class=\\"target\\"></div>
-  <iframe class=\\"iframeTarget\\"></iframe>
-
-
-<div class=\\"css-modules-myClassName_29qd4Wo\\">Water</div><div class=\\"css-modules-myComposingClass_EtB1JLd css-modules-local-scoped-className_2SS6AUo\\">Ground</div></body></html>"
-`;
-
-exports[`loader should work with css modules when the "injectType" option is "lazySingletonStyleTag": errors 1`] = `Array []`;
-
-exports[`loader should work with css modules when the "injectType" option is "lazySingletonStyleTag": warnings 1`] = `Array []`;
-
 exports[`loader should work with css modules when the "injectType" option is "lazyStyleTag": DOM 1`] = `
 "<!DOCTYPE html><html><head>
   <title>style-loader test</title>
@@ -729,34 +424,6 @@ exports[`loader should work with css modules when the "injectType" option is "li
 exports[`loader should work with css modules when the "injectType" option is "linkTag": errors 1`] = `Array []`;
 
 exports[`loader should work with css modules when the "injectType" option is "linkTag": warnings 1`] = `Array []`;
-
-exports[`loader should work with css modules when the "injectType" option is "singletonStyleTag": DOM 1`] = `
-"<!DOCTYPE html><html><head>
-  <title>style-loader test</title>
-  <style id=\\"existing-style\\">.existing { color: yellow }</style>
-<style>.css-modules-local-scoped-className_2SS6AUo {
-  background: red;
-}
-.css-modules-myClassName_29qd4Wo {
-  background: red;
-}
-
-.css-modules-myComposingClass_EtB1JLd {
-  color: blue;
-}
-</style></head>
-<body>
-  <h1>Body</h1>
-  <div class=\\"target\\"></div>
-  <iframe class=\\"iframeTarget\\"></iframe>
-
-
-<div class=\\"css-modules-myClassName_29qd4Wo\\">Water</div><div class=\\"css-modules-myComposingClass_EtB1JLd css-modules-local-scoped-className_2SS6AUo\\">Ground</div></body></html>"
-`;
-
-exports[`loader should work with css modules when the "injectType" option is "singletonStyleTag": errors 1`] = `Array []`;
-
-exports[`loader should work with css modules when the "injectType" option is "singletonStyleTag": warnings 1`] = `Array []`;
 
 exports[`loader should work with css modules when the "injectType" option is "styleTag": DOM 1`] = `
 "<!DOCTYPE html><html><head>

--- a/test/__snapshots__/validate-options.test.js.snap
+++ b/test/__snapshots__/validate-options.test.js.snap
@@ -16,7 +16,7 @@ exports[`validate options should throw an error on the "esModule" option with "t
 exports[`validate options should throw an error on the "injectType" option with "unknown" value 1`] = `
 "Invalid options object. Style Loader has been initialised using an options object that does not match the API schema.
  - options.injectType should be one of these:
-   \\"styleTag\\" | \\"singletonStyleTag\\" | \\"lazyStyleTag\\" | \\"lazySingletonStyleTag\\" | \\"linkTag\\"
+   \\"styleTag\\" | \\"lazyStyleTag\\" | \\"linkTag\\"
    -> Allows to setup how styles will be injected into DOM (https://github.com/webpack-contrib/style-loader#injecttype)."
 `;
 

--- a/test/attributes-option.test.js
+++ b/test/attributes-option.test.js
@@ -8,13 +8,7 @@ import {
 } from './helpers/index';
 
 describe('"attributes" option', () => {
-  const injectTypes = [
-    'styleTag',
-    'singletonStyleTag',
-    'lazyStyleTag',
-    'lazySingletonStyleTag',
-    'linkTag',
-  ];
+  const injectTypes = ['styleTag', 'lazyStyleTag', 'linkTag'];
 
   injectTypes.forEach((injectType) => {
     it(`should add attributes to tag when the "injectType" option is "${injectType}"`, async () => {

--- a/test/esModule-option.test.js
+++ b/test/esModule-option.test.js
@@ -10,13 +10,7 @@ import {
 } from './helpers/index';
 
 describe('"esModule" option', () => {
-  const injectTypes = [
-    'styleTag',
-    'singletonStyleTag',
-    'lazyStyleTag',
-    'lazySingletonStyleTag',
-    'linkTag',
-  ];
+  const injectTypes = ['styleTag', 'lazyStyleTag', 'linkTag'];
 
   injectTypes.forEach((injectType) => {
     it(`should work when not specified and when the "injectType" option is "${injectType}"`, async () => {

--- a/test/fixtures/css-modules.js
+++ b/test/fixtures/css-modules.js
@@ -1,17 +1,19 @@
 import styles from './css-modules.css';
 
-const node1 = document.createElement("DIV");
-const textNode1 = document.createTextNode("Water");
+if (styles) {
+  const node1 = document.createElement("DIV");
+  const textNode1 = document.createTextNode("Water");
 
-node1.appendChild(textNode1);
-node1.className = styles.myClassName;
+  node1.appendChild(textNode1);
+  node1.className = styles.myClassName;
 
-document.body.appendChild(node1);
+  document.body.appendChild(node1);
 
-const node2 = document.createElement("DIV");
-const textNode2 = document.createTextNode("Ground");
+  const node2 = document.createElement("DIV");
+  const textNode2 = document.createTextNode("Ground");
 
-node2.appendChild(textNode2);
-node2.className = styles.myComposingClass;
+  node2.appendChild(textNode2);
+  node2.className = styles.myComposingClass;
 
-document.body.appendChild(node2);
+  document.body.appendChild(node2);
+}

--- a/test/fixtures/lazy-element.js
+++ b/test/fixtures/lazy-element.js
@@ -3,8 +3,11 @@ const element = document.createElement('div');
 element.id = "test-shadow";
 document.body.appendChild(element);
 
-const styles = require('./style.css');
-const stylesOther = require('./style-other.css');
+let styles = require('./style.css');
+let stylesOther = require('./style-other.css');
+
+styles = styles.__esModule ? styles.default : styles;
+stylesOther = stylesOther.__esModule ? stylesOther.default : stylesOther;
 
 styles.use();
 stylesOther.use();

--- a/test/fixtures/lazy-negative-refs.js
+++ b/test/fixtures/lazy-negative-refs.js
@@ -1,4 +1,6 @@
-const css = require('./style.css');
+let css = require('./style.css');
+
+css = css.__esModule ? css.default : css;
 
 // ref still 0
 css.unuse();

--- a/test/fixtures/lazy-nonce-require.js
+++ b/test/fixtures/lazy-nonce-require.js
@@ -1,6 +1,8 @@
 __webpack_nonce__ = '12345678';
 
-const styles = require('./style.css');
+let styles = require('./style.css');
+
+styles = styles.__esModule ? styles.default : styles;
 
 styles.use();
 

--- a/test/fixtures/singleton-one.css
+++ b/test/fixtures/singleton-one.css
@@ -1,3 +1,0 @@
-.class-one {
-  color: red;
-}

--- a/test/fixtures/singleton-two.css
+++ b/test/fixtures/singleton-two.css
@@ -1,3 +1,0 @@
-.class-two {
-  color: red;
-}

--- a/test/fixtures/singleton.js
+++ b/test/fixtures/singleton.js
@@ -1,2 +1,0 @@
-import './singleton-one.css';
-import './singleton-two.css';

--- a/test/injectType-option.test.js
+++ b/test/injectType-option.test.js
@@ -10,13 +10,7 @@ import {
 } from './helpers/index';
 
 describe('"injectType" option', () => {
-  const injectTypes = [
-    'styleTag',
-    'singletonStyleTag',
-    'lazyStyleTag',
-    'lazySingletonStyleTag',
-    'linkTag',
-  ];
+  const injectTypes = ['styleTag', 'lazyStyleTag', 'linkTag'];
 
   injectTypes.forEach((injectType) => {
     it(`should work when the "injectType" option is "${injectType}"`, async () => {

--- a/test/insert-option.test.js
+++ b/test/insert-option.test.js
@@ -9,13 +9,7 @@ import {
 } from './helpers/index';
 
 describe('"insert" option', () => {
-  const injectTypes = [
-    'styleTag',
-    'singletonStyleTag',
-    'lazyStyleTag',
-    'lazySingletonStyleTag',
-    'linkTag',
-  ];
+  const injectTypes = ['styleTag', 'lazyStyleTag', 'linkTag'];
 
   injectTypes.forEach((injectType) => {
     it(`should insert styles into "head" bottom when not specified and when the "injectType" option is "${injectType}"`, async () => {

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -15,13 +15,7 @@ import {
 } from './helpers/index';
 
 describe('loader', () => {
-  const injectTypes = [
-    'styleTag',
-    'singletonStyleTag',
-    'lazyStyleTag',
-    'lazySingletonStyleTag',
-    'linkTag',
-  ];
+  const injectTypes = ['styleTag', 'lazyStyleTag', 'linkTag'];
 
   it('should work', async () => {
     const compiler = getCompiler('./simple.js');
@@ -287,7 +281,7 @@ describe('loader', () => {
       expect(getErrors(stats)).toMatchSnapshot('errors');
     });
 
-    if (['lazyStyleTag', 'lazySingletonStyleTag'].includes(injectType)) {
+    if (['lazyStyleTag'].includes(injectType)) {
       it(`should work when ref is negative when the "injectType" option is "${injectType}"`, async () => {
         expect.assertions(3);
 

--- a/test/runtime/__snapshots__/injectStylesIntoStyleTag.test.js.snap
+++ b/test/runtime/__snapshots__/injectStylesIntoStyleTag.test.js.snap
@@ -57,71 +57,67 @@ exports[`addStyle should work with updates #5 1`] = `"<head><title>Title</title>
 
 exports[`addStyle should work with updates #5 2`] = `"<head><title>Title</title><style media=\\"screen and (min-width:640px)\\">.foo { color: blue }</style></head><body><h1>Hello world</h1></body>"`;
 
-exports[`addStyle should work with updates #6 1`] = `"<head><title>Title</title><style>.foo { color: red }.bar { color: yellow }</style></head><body><h1>Hello world</h1></body>"`;
+exports[`addStyle should work with updates #6 1`] = `"<head><title>Title</title><style>.foo { color: red }</style><style>.bar { color: blue }</style></head><body><h1>Hello world</h1></body>"`;
 
-exports[`addStyle should work with updates #6 2`] = `"<head><title>Title</title><style>.foo { color: blue }.bar { color: yellow }</style></head><body><h1>Hello world</h1></body>"`;
+exports[`addStyle should work with updates #6 2`] = `"<head><title>Title</title><style>.foo { color: green }</style><style>.bar { color: black }</style></head><body><h1>Hello world</h1></body>"`;
 
-exports[`addStyle should work with updates #7 1`] = `"<head><title>Title</title><style>.foo { color: red }</style><style>.bar { color: blue }</style></head><body><h1>Hello world</h1></body>"`;
-
-exports[`addStyle should work with updates #7 2`] = `"<head><title>Title</title><style>.foo { color: green }</style><style>.bar { color: black }</style></head><body><h1>Hello world</h1></body>"`;
-
-exports[`addStyle should work with updates #8 1`] = `
+exports[`addStyle should work with updates #7 1`] = `
 "<head><title>Title</title><style media=\\"screen and (min-width: 320px)\\">.foo { color: red }
 /*# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInN0eWxlLTI2LTEuY3NzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUFBLGNBQXFCLGVBQWUsRUFBRSIsImZpbGUiOiJzdHlsZS0yNi0xLmNzcyIsInNvdXJjZXNDb250ZW50IjpbIkBtZWRpYSBzY3JlZW4gYW5kIChtYXgtd2lkdGg6IDMyMHB4KSB7IC5mb28geyBjb2xvcjogcmVkIH0gfSJdfQ== */</style><style media=\\"screen and (max-width: 240px)\\">.bar { color: yellow }
 /*# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInN0eWxlLTI2LTIuY3NzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUFBLGNBQXFCLGVBQWUsRUFBRSIsImZpbGUiOiJzdHlsZS0yNi0yLmNzcyIsInNvdXJjZXNDb250ZW50IjpbIkBtZWRpYSBzY3JlZW4gYW5kIChtYXgtd2lkdGg6IDI0MHB4KSB7IC5iYXIgeyBjb2xvcjogeWVsbG93IH0gfSJdfQ== */</style></head><body><h1>Hello world</h1></body>"
 `;
 
-exports[`addStyle should work with updates #8 2`] = `
+exports[`addStyle should work with updates #7 2`] = `
 "<head><title>Title</title><style media=\\"screen and (min-width: 640px)\\">.foo { color: black }
 /*# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInN0eWxlLTI2LTEuY3NzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJCQkJCLGNBQXFCLGVBQWUsRUFBRSIsImZpbGUiOiJzdHlsZS0yNi0xLmNzcyIsInNvdXJjZXNDb250ZW50IjpbIkBtZWRpYSBzY3JlZW4gYW5kIChtaW4td2lkdGg6IDY0MHB4KSB7IC5mb28geyBjb2xvcjogYmxhY2sgfSB9Il19 */</style><style media=\\"screen and (max-width: 1240px)\\">.bar { color: black }
 /*# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInN0eWxlLTI2LTIuY3NzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJCQkJCLGNBQXFCLGVBQWUsRUFBRSIsImZpbGUiOiJzdHlsZS0yNi0yLmNzcyIsInNvdXJjZXNDb250ZW50IjpbIkBtZWRpYSBzY3JlZW4gYW5kIChtYXgtd2lkdGg6IDEyNDBweCkgeyAuYmFyIHsgY29sb3I6IGJsYWNrIH0gfSJdfQ== */</style></head><body><h1>Hello world</h1></body>"
 `;
 
-exports[`addStyle should work with updates #8 3`] = `"<head><title>Title</title></head><body><h1>Hello world</h1></body>"`;
+exports[`addStyle should work with updates #7 3`] = `"<head><title>Title</title></head><body><h1>Hello world</h1></body>"`;
 
-exports[`addStyle should work with updates #9 1`] = `"<head><title>Title</title><style>.foo { color: red }</style></head><body><h1>Hello world</h1></body>"`;
+exports[`addStyle should work with updates #8 1`] = `"<head><title>Title</title><style>.foo { color: red }</style></head><body><h1>Hello world</h1></body>"`;
 
-exports[`addStyle should work with updates #9 2`] = `"<head><title>Title</title><style>.foo { color: black }</style><style>.foo { color: red }</style><style>.foo { color: yellow }</style></head><body><h1>Hello world</h1></body>"`;
+exports[`addStyle should work with updates #8 2`] = `"<head><title>Title</title><style>.foo { color: black }</style><style>.foo { color: red }</style><style>.foo { color: yellow }</style></head><body><h1>Hello world</h1></body>"`;
 
-exports[`addStyle should work with updates #10 1`] = `"<head><title>Title</title><style>.foo { color: red }</style><style>.bar { color: blue }</style></head><body><h1>Hello world</h1></body>"`;
+exports[`addStyle should work with updates #8 3`] = `"<head><title>Title</title><style>.foo { color: red }</style><style>.bar { color: blue }</style></head><body><h1>Hello world</h1></body>"`;
 
-exports[`addStyle should work with updates #10 2`] = `"<head><title>Title</title><style>.foo { color: black }</style><style>.bar { color: white }</style></head><body><h1>Hello world</h1></body>"`;
+exports[`addStyle should work with updates #8 4`] = `"<head><title>Title</title><style>.foo { color: black }</style><style>.bar { color: white }</style></head><body><h1>Hello world</h1></body>"`;
 
-exports[`addStyle should work with updates #11 1`] = `"<head><title>Title</title><style>.foo { color: red }</style><style>.bar { color: blue }</style><script src=\\"https://example.com/script.js\\" id=\\"id\\"></script></head><body><h1>Hello world</h1></body>"`;
+exports[`addStyle should work with updates #9 1`] = `"<head><title>Title</title><style>.foo { color: red }</style><style>.bar { color: blue }</style><script src=\\"https://example.com/script.js\\" id=\\"id\\"></script></head><body><h1>Hello world</h1></body>"`;
 
-exports[`addStyle should work with updates #11 2`] = `"<head><title>Title</title><style>.foo { color: black }</style><style>.bar { color: white }</style><script src=\\"https://example.com/script.js\\" id=\\"id\\"></script></head><body><h1>Hello world</h1></body>"`;
+exports[`addStyle should work with updates #9 2`] = `"<head><title>Title</title><style>.foo { color: black }</style><style>.bar { color: white }</style><script src=\\"https://example.com/script.js\\" id=\\"id\\"></script></head><body><h1>Hello world</h1></body>"`;
 
-exports[`addStyle should work with updates #12 1`] = `"<head><title>Title</title><style>.order { color: red }</style><style>.@import url(\\"https://fonts.googleapis.com/css?family=Roboto&display=swap\\");</style><style>.order { color: blue }</style><style>.@import url(\\"https://fonts.googleapis.com/css?family=Roboto&display=swap\\");</style><style>.order { color: red }</style><style>.@import url(\\"https://fonts.googleapis.com/css?family=Roboto&display=swap\\");</style><style media=\\"screen and (min-width: 2000px)\\">.order { color: blue }</style><style>.@import url(\\"https://fonts.googleapis.com/css?family=Roboto&display=swap\\");</style></head><body><h1>Hello world</h1></body>"`;
+exports[`addStyle should work with updates #10 1`] = `"<head><title>Title</title><style>.order { color: red }</style><style>.@import url(\\"https://fonts.googleapis.com/css?family=Roboto&display=swap\\");</style><style>.order { color: blue }</style><style>.@import url(\\"https://fonts.googleapis.com/css?family=Roboto&display=swap\\");</style><style>.order { color: red }</style><style>.@import url(\\"https://fonts.googleapis.com/css?family=Roboto&display=swap\\");</style><style media=\\"screen and (min-width: 2000px)\\">.order { color: blue }</style><style>.@import url(\\"https://fonts.googleapis.com/css?family=Roboto&display=swap\\");</style></head><body><h1>Hello world</h1></body>"`;
 
-exports[`addStyle should work with updates #12 2`] = `"<head><title>Title</title><style>.order { color: orange }</style><style>.@import url(\\"https://fonts.googleapis.com/css?family=Roboto&display=swap\\");</style><style>.order { color: blue }</style><style>.@import url(\\"https://fonts.googleapis.com/css?family=Roboto&display=swap\\");</style><style>.order { color: orange }</style><style>.@import url(\\"https://fonts.googleapis.com/css?family=Roboto&display=swap\\");</style><style media=\\"screen and (min-width: 2000px)\\">.order { color: blue }</style><style>.@import url(\\"https://fonts.googleapis.com/css?family=Roboto&display=swap\\");</style></head><body><h1>Hello world</h1></body>"`;
+exports[`addStyle should work with updates #10 2`] = `"<head><title>Title</title><style>.order { color: orange }</style><style>.@import url(\\"https://fonts.googleapis.com/css?family=Roboto&display=swap\\");</style><style>.order { color: blue }</style><style>.@import url(\\"https://fonts.googleapis.com/css?family=Roboto&display=swap\\");</style><style>.order { color: orange }</style><style>.@import url(\\"https://fonts.googleapis.com/css?family=Roboto&display=swap\\");</style><style media=\\"screen and (min-width: 2000px)\\">.order { color: blue }</style><style>.@import url(\\"https://fonts.googleapis.com/css?family=Roboto&display=swap\\");</style></head><body><h1>Hello world</h1></body>"`;
 
-exports[`addStyle should work with updates #12 3`] = `"<head><title>Title</title><style>.foo { color: red }</style><style>.bar { color: blue }</style></head><body><h1>Hello world</h1></body>"`;
+exports[`addStyle should work with updates #11 1`] = `"<head><title>Title</title><style>.foo { color: red }</style><style>.bar { color: blue }</style></head><body><h1>Hello world</h1></body>"`;
 
-exports[`addStyle should work with updates #12 4`] = `"<head><title>Title</title></head><body><h1>Hello world</h1></body>"`;
+exports[`addStyle should work with updates #11 2`] = `"<head><title>Title</title></head><body><h1>Hello world</h1></body>"`;
+
+exports[`addStyle should work with updates #12 1`] = `"<head><title>Title</title><style>.red { color: red }</style><style>.green { color: green }</style><style>.blue { color: blue }</style></head><body><h1>Hello world</h1></body>"`;
+
+exports[`addStyle should work with updates #12 2`] = `"<head><title>Title</title><style>.red { color: black }</style><style>.green { color: green }</style><style>.blue { color: blue }</style></head><body><h1>Hello world</h1></body>"`;
+
+exports[`addStyle should work with updates #12 3`] = `"<head><title>Title</title><style>.red { color: black }</style><style>.green { color: black }</style><style>.blue { color: blue }</style></head><body><h1>Hello world</h1></body>"`;
+
+exports[`addStyle should work with updates #12 4`] = `"<head><title>Title</title><style>.red { color: black }</style><style>.green { color: black }</style><style>.blue { color: black }</style></head><body><h1>Hello world</h1></body>"`;
+
+exports[`addStyle should work with updates #12 5`] = `"<head><title>Title</title><style>.green { color: black }</style><style>.blue { color: black }</style></head><body><h1>Hello world</h1></body>"`;
+
+exports[`addStyle should work with updates #12 6`] = `"<head><title>Title</title><style>.blue { color: black }</style></head><body><h1>Hello world</h1></body>"`;
+
+exports[`addStyle should work with updates #12 7`] = `"<head><title>Title</title></head><body><h1>Hello world</h1></body>"`;
 
 exports[`addStyle should work with updates #13 1`] = `"<head><title>Title</title><style>.red { color: red }</style><style>.green { color: green }</style><style>.blue { color: blue }</style></head><body><h1>Hello world</h1></body>"`;
 
-exports[`addStyle should work with updates #13 2`] = `"<head><title>Title</title><style>.red { color: black }</style><style>.green { color: green }</style><style>.blue { color: blue }</style></head><body><h1>Hello world</h1></body>"`;
+exports[`addStyle should work with updates #13 2`] = `"<head><title>Title</title><style>.red { color: red }</style><style>.green { color: black }</style><style>.blue { color: blue }</style></head><body><h1>Hello world</h1></body>"`;
 
-exports[`addStyle should work with updates #13 3`] = `"<head><title>Title</title><style>.red { color: black }</style><style>.green { color: black }</style><style>.blue { color: blue }</style></head><body><h1>Hello world</h1></body>"`;
+exports[`addStyle should work with updates #13 3`] = `"<head><title>Title</title><style>.red { color: red }</style><style>.green { color: black }</style><style>.blue { color: blue }</style><style>.white { color: white }</style></head><body><h1>Hello world</h1></body>"`;
 
-exports[`addStyle should work with updates #13 4`] = `"<head><title>Title</title><style>.red { color: black }</style><style>.green { color: black }</style><style>.blue { color: black }</style></head><body><h1>Hello world</h1></body>"`;
+exports[`addStyle should work with updates #13 4`] = `"<head><title>Title</title><style>.green { color: black }</style><style>.blue { color: blue }</style><style>.white { color: white }</style></head><body><h1>Hello world</h1></body>"`;
 
-exports[`addStyle should work with updates #13 5`] = `"<head><title>Title</title><style>.green { color: black }</style><style>.blue { color: black }</style></head><body><h1>Hello world</h1></body>"`;
-
-exports[`addStyle should work with updates #13 6`] = `"<head><title>Title</title><style>.blue { color: black }</style></head><body><h1>Hello world</h1></body>"`;
-
-exports[`addStyle should work with updates #13 7`] = `"<head><title>Title</title></head><body><h1>Hello world</h1></body>"`;
-
-exports[`addStyle should work with updates #14 1`] = `"<head><title>Title</title><style>.red { color: red }</style><style>.green { color: green }</style><style>.blue { color: blue }</style></head><body><h1>Hello world</h1></body>"`;
-
-exports[`addStyle should work with updates #14 2`] = `"<head><title>Title</title><style>.red { color: red }</style><style>.green { color: black }</style><style>.blue { color: blue }</style></head><body><h1>Hello world</h1></body>"`;
-
-exports[`addStyle should work with updates #14 3`] = `"<head><title>Title</title><style>.red { color: red }</style><style>.green { color: black }</style><style>.blue { color: blue }</style><style>.white { color: white }</style></head><body><h1>Hello world</h1></body>"`;
-
-exports[`addStyle should work with updates #14 4`] = `"<head><title>Title</title><style>.green { color: black }</style><style>.blue { color: blue }</style><style>.white { color: white }</style></head><body><h1>Hello world</h1></body>"`;
-
-exports[`addStyle should work with updates #14 5`] = `"<head><title>Title</title><style>.green { color: black }</style><style>.white { color: white }</style></head><body><h1>Hello world</h1></body>"`;
+exports[`addStyle should work with updates #13 5`] = `"<head><title>Title</title><style>.green { color: black }</style><style>.white { color: white }</style></head><body><h1>Hello world</h1></body>"`;
 
 exports[`addStyle should work with updates 1`] = `"<head><title>Title</title><style>.foo { color: red }</style></head><body><h1>Hello world</h1></body>"`;
 

--- a/test/runtime/injectStylesIntoStyleTag.test.js
+++ b/test/runtime/injectStylesIntoStyleTag.test.js
@@ -379,26 +379,6 @@ describe('addStyle', () => {
   });
 
   it('should work with updates #6', () => {
-    const update = injectStylesIntoStyleTag(
-      getId(),
-      [
-        ['./style-24-1.css', '.foo { color: red }', ''],
-        ['./style-24-2.css', '.bar { color: yellow }', ''],
-      ],
-      { singleton: true }
-    );
-
-    expect(document.documentElement.innerHTML).toMatchSnapshot();
-
-    update([
-      ['./style-24-1.css', '.foo { color: blue }', ''],
-      ['./style-24-2.css', '.bar { color: yellow }', ''],
-    ]);
-
-    expect(document.documentElement.innerHTML).toMatchSnapshot();
-  });
-
-  it('should work with updates #7', () => {
     const update = injectStylesIntoStyleTag(getId(), [
       ['./style-25-1.css', '.foo { color: red }', ''],
       ['./style-25-2.css', '.bar { color: blue }', ''],
@@ -414,7 +394,7 @@ describe('addStyle', () => {
     expect(document.documentElement.innerHTML).toMatchSnapshot();
   });
 
-  it('should work with updates #8', () => {
+  it('should work with updates #7', () => {
     const update = injectStylesIntoStyleTag(getId(), [
       [
         './style-26-1.css',
@@ -490,7 +470,7 @@ describe('addStyle', () => {
     expect(document.documentElement.innerHTML).toMatchSnapshot();
   });
 
-  it('should work with updates #9', () => {
+  it('should work with updates #8', () => {
     const update = injectStylesIntoStyleTag(getId(), [
       ['./style-27.css', '.foo { color: red }', ''],
     ]);
@@ -506,7 +486,7 @@ describe('addStyle', () => {
     expect(document.documentElement.innerHTML).toMatchSnapshot();
   });
 
-  it('should work with updates #10', () => {
+  it('should work with updates #8', () => {
     const update = injectStylesIntoStyleTag(
       getId(),
       [
@@ -531,7 +511,7 @@ describe('addStyle', () => {
     window._lastElementInsertedByStyleLoader = null;
   });
 
-  it('should work with updates #11', () => {
+  it('should work with updates #9', () => {
     document.head.innerHTML =
       '<title>Title</title><script src="https://example.com/script.js" id="id"></script>';
 
@@ -556,7 +536,7 @@ describe('addStyle', () => {
     expect(document.documentElement.innerHTML).toMatchSnapshot();
   });
 
-  it('should work with updates #12', () => {
+  it('should work with updates #10', () => {
     const update = injectStylesIntoStyleTag(getId(), [
       ['./order-1.css', '.order { color: red }', ''],
       [
@@ -624,7 +604,7 @@ describe('addStyle', () => {
     expect(document.documentElement.innerHTML).toMatchSnapshot();
   });
 
-  it('should work with updates #12', () => {
+  it('should work with updates #11', () => {
     const update = injectStylesIntoStyleTag(getId(), [
       ['./style-30.css', '.foo { color: red }', ''],
       ['./style-31.css', '.bar { color: blue }', ''],
@@ -637,7 +617,7 @@ describe('addStyle', () => {
     expect(document.documentElement.innerHTML).toMatchSnapshot();
   });
 
-  it('should work with updates #13', () => {
+  it('should work with updates #12', () => {
     const update1 = injectStylesIntoStyleTag(getId(), [
       ['./style-32.css', '.red { color: red }', ''],
     ]);
@@ -675,7 +655,7 @@ describe('addStyle', () => {
     expect(document.documentElement.innerHTML).toMatchSnapshot();
   });
 
-  it('should work with updates #14', () => {
+  it('should work with updates #13', () => {
     const update1 = injectStylesIntoStyleTag(getId(), [
       ['./style-35.css', '.red { color: red }', ''],
     ]);

--- a/test/validate-options.test.js
+++ b/test/validate-options.test.js
@@ -3,13 +3,7 @@ import { getCompiler, compile } from './helpers';
 describe('validate options', () => {
   const tests = {
     injectType: {
-      success: [
-        'styleTag',
-        'singletonStyleTag',
-        'lazyStyleTag',
-        'lazySingletonStyleTag',
-        'linkTag',
-      ],
+      success: ['styleTag', 'lazyStyleTag', 'linkTag'],
       failure: ['unknown'],
     },
     attributes: {


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [x] **metadata update**

### Motivation / Use-Case

next version

### Breaking Changes

Yes. List:
- support >= 13.10 version of node
- drop support string modules (you can't return a string from a loader to style-loader)
- drop support old browsers (< IE11)
- remove `singletonStyleTag` and `lazySingletonStyleTag` values from the `injectType` option
- refactor: the `esModule` option is `true` by default

### Additional Info
