### PR TITLE
fix: checking that the list of modules is an array

### DIFF
--- a/src/runtime/injectStylesIntoStyleTag.js
+++ b/src/runtime/injectStylesIntoStyleTag.js
@@ -47,6 +47,10 @@ const getTarget = (function getTarget() {
 })();
 
 function addModulesToDom(id, list, options) {
+  if (Object.prototype.toString.call(list) !== '[object Array]') {
+    return;
+  }
+
   id = options.base ? id + options.base : id;
 
   if (!stylesInDom[id]) {

--- a/test/runtime/__snapshots__/injectStylesIntoStyleTag.test.js.snap
+++ b/test/runtime/__snapshots__/injectStylesIntoStyleTag.test.js.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`addStyle issue 447 1`] = `"<head><title>Title</title></head><body><h1>Hello world</h1></body>"`;
+
 exports[`addStyle should throw error with incorrect "insert" option 1`] = `"Couldn't find a style target. This probably means that the value for the 'insert' parameter is invalid."`;
 
 exports[`addStyle should throw error with invalid "insert" option 1`] = `"'#test><><><' is not a valid selector"`;

--- a/test/runtime/injectStylesIntoStyleTag.test.js
+++ b/test/runtime/injectStylesIntoStyleTag.test.js
@@ -706,4 +706,10 @@ describe('addStyle', () => {
 
     expect(document.documentElement.innerHTML).toMatchSnapshot();
   });
+
+  it('issue 447', () => {
+    injectStylesIntoStyleTag(getId(), {});
+
+    expect(document.documentElement.innerHTML).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

fixes #447

### Breaking Changes

No

### Additional Info

Supporting non-array list of modules will be removed in next version, my recommendation is https://github.com/webpack-contrib/style-loader/issues/447#issuecomment-568685446