### PR TITLE
fix: check if 'btoa' exists for old IE versions

### DIFF
--- a/src/runtime/injectStylesIntoStyleTag.js
+++ b/src/runtime/injectStylesIntoStyleTag.js
@@ -187,7 +187,7 @@ function applyToTag(style, options, obj) {
     style.removeAttribute('media');
   }
 
-  if (sourceMap && btoa) {
+  if (sourceMap && typeof btoa !== 'undefined') {
     css += `\n/*# sourceMappingURL=data:application/json;base64,${btoa(
       unescape(encodeURIComponent(JSON.stringify(sourceMap)))
     )} */`;


### PR DESCRIPTION
This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case
If the `btoa` function does not exist, an error will occur as follows.

```
btoa is not defined
```

### Breaking Changes

### Additional Info
