### PR TITLE
feat: added cssPostProcess option

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -32,6 +32,10 @@ loaderApi.pitch = function loader(request) {
     insert: options.insert,
     base: options.base,
   };
+  const cssPostProcess =
+    typeof options.cssPostProcess !== 'function'
+      ? null
+      : JSON.stringify(options.cssPostProcess);
 
   switch (injectType) {
     case 'linkTag': {
@@ -87,6 +91,8 @@ if (module.hot) {
 var options = ${JSON.stringify(runtimeOptions)};
 
 options.insert = ${insert};
+
+options.cssPostProcess = ${cssPostProcess};
 
 var update = api(content, options);
 
@@ -184,6 +190,7 @@ var update;
 var options = ${JSON.stringify(runtimeOptions)};
 
 options.insert = ${insert};
+options.cssPostProcess = ${cssPostProcess};
 options.singleton = ${isSingleton};
 
 var exported = {};
@@ -294,6 +301,7 @@ if (module.hot) {
 var options = ${JSON.stringify(runtimeOptions)};
 
 options.insert = ${insert};
+options.cssPostProcess = ${cssPostProcess};
 options.singleton = ${isSingleton};
 
 var update = api(content, options);

--- a/src/options.json
+++ b/src/options.json
@@ -33,6 +33,10 @@
     "esModule": {
       "description": "Use the ES modules syntax (https://github.com/webpack-contrib/css-loader#esmodule).",
       "type": "boolean"
+    },
+    "cssPostProcess": {
+      "description": "Allows to post process the CSS in the browser before it is injected in the page (https://github.com/webpack-contrib/style-loader#csspostprocess)",
+      "instanceof": "Function"
     }
   },
   "additionalProperties": false

--- a/src/runtime/injectStylesIntoStyleTag.js
+++ b/src/runtime/injectStylesIntoStyleTag.js
@@ -193,6 +193,10 @@ function applyToTag(style, options, obj) {
     )} */`;
   }
 
+  if (typeof options.cssPostProcess === 'function') {
+    css = options.cssPostProcess(css);
+  }
+
   // For old IE
   /* istanbul ignore if  */
   if (style.styleSheet) {

--- a/test/__snapshots__/validate-options.test.js.snap
+++ b/test/__snapshots__/validate-options.test.js.snap
@@ -7,6 +7,18 @@ exports[`validate options should throw an error on the "attributes" option with 
    -> Adds custom attributes to tag (https://github.com/webpack-contrib/style-loader#attributes)."
 `;
 
+exports[`validate options should throw an error on the "cssPostProcess" option with "{}" value 1`] = `
+"Invalid options object. Style Loader has been initialized using an options object that does not match the API schema.
+ - options.cssPostProcess should be an instance of function.
+   -> Allows to post process the CSS in the browser before it is injected in the page (https://github.com/webpack-contrib/style-loader#csspostprocess)"
+`;
+
+exports[`validate options should throw an error on the "cssPostProcess" option with "true" value 1`] = `
+"Invalid options object. Style Loader has been initialized using an options object that does not match the API schema.
+ - options.cssPostProcess should be an instance of function.
+   -> Allows to post process the CSS in the browser before it is injected in the page (https://github.com/webpack-contrib/style-loader#csspostprocess)"
+`;
+
 exports[`validate options should throw an error on the "esModule" option with "true" value 1`] = `
 "Invalid options object. Style Loader has been initialized using an options object that does not match the API schema.
  - options.esModule should be a boolean.
@@ -33,47 +45,47 @@ exports[`validate options should throw an error on the "insert" option with "tru
 exports[`validate options should throw an error on the "unknown" option with "/test/" value 1`] = `
 "Invalid options object. Style Loader has been initialized using an options object that does not match the API schema.
  - options has an unknown property 'unknown'. These properties are valid:
-   object { injectType?, attributes?, insert?, base?, esModule? }"
+   object { injectType?, attributes?, insert?, base?, esModule?, cssPostProcess? }"
 `;
 
 exports[`validate options should throw an error on the "unknown" option with "[]" value 1`] = `
 "Invalid options object. Style Loader has been initialized using an options object that does not match the API schema.
  - options has an unknown property 'unknown'. These properties are valid:
-   object { injectType?, attributes?, insert?, base?, esModule? }"
+   object { injectType?, attributes?, insert?, base?, esModule?, cssPostProcess? }"
 `;
 
 exports[`validate options should throw an error on the "unknown" option with "{"foo":"bar"}" value 1`] = `
 "Invalid options object. Style Loader has been initialized using an options object that does not match the API schema.
  - options has an unknown property 'unknown'. These properties are valid:
-   object { injectType?, attributes?, insert?, base?, esModule? }"
+   object { injectType?, attributes?, insert?, base?, esModule?, cssPostProcess? }"
 `;
 
 exports[`validate options should throw an error on the "unknown" option with "{}" value 1`] = `
 "Invalid options object. Style Loader has been initialized using an options object that does not match the API schema.
  - options has an unknown property 'unknown'. These properties are valid:
-   object { injectType?, attributes?, insert?, base?, esModule? }"
+   object { injectType?, attributes?, insert?, base?, esModule?, cssPostProcess? }"
 `;
 
 exports[`validate options should throw an error on the "unknown" option with "1" value 1`] = `
 "Invalid options object. Style Loader has been initialized using an options object that does not match the API schema.
  - options has an unknown property 'unknown'. These properties are valid:
-   object { injectType?, attributes?, insert?, base?, esModule? }"
+   object { injectType?, attributes?, insert?, base?, esModule?, cssPostProcess? }"
 `;
 
 exports[`validate options should throw an error on the "unknown" option with "false" value 1`] = `
 "Invalid options object. Style Loader has been initialized using an options object that does not match the API schema.
  - options has an unknown property 'unknown'. These properties are valid:
-   object { injectType?, attributes?, insert?, base?, esModule? }"
+   object { injectType?, attributes?, insert?, base?, esModule?, cssPostProcess? }"
 `;
 
 exports[`validate options should throw an error on the "unknown" option with "test" value 1`] = `
 "Invalid options object. Style Loader has been initialized using an options object that does not match the API schema.
  - options has an unknown property 'unknown'. These properties are valid:
-   object { injectType?, attributes?, insert?, base?, esModule? }"
+   object { injectType?, attributes?, insert?, base?, esModule?, cssPostProcess? }"
 `;
 
 exports[`validate options should throw an error on the "unknown" option with "true" value 1`] = `
 "Invalid options object. Style Loader has been initialized using an options object that does not match the API schema.
  - options has an unknown property 'unknown'. These properties are valid:
-   object { injectType?, attributes?, insert?, base?, esModule? }"
+   object { injectType?, attributes?, insert?, base?, esModule?, cssPostProcess? }"
 `;

--- a/test/runtime/__snapshots__/injectStylesIntoStyleTag.test.js.snap
+++ b/test/runtime/__snapshots__/injectStylesIntoStyleTag.test.js.snap
@@ -22,6 +22,8 @@ exports[`addStyle should work with "attributes" option 1`] = `"<head><title>Titl
 
 exports[`addStyle should work with "base" option 1`] = `"<head><title>Title</title><style>.foo { color: red }</style></head><body><h1>Hello world</h1></body>"`;
 
+exports[`addStyle should work with "cssPostProcess" 1`] = `"<head><title>Title</title><style>.foo { color: red } #root { color: yellow }</style></head><body><h1>Hello world</h1><div><div id=\\"root\\" data-color=\\"yellow\\"></div></div></body>"`;
+
 exports[`addStyle should work with "insert" option #2 1`] = `"<head><title>Title</title></head><body><h1>Hello world</h1><style>.foo { color: red }</style><style>.bar { color: blue }</style></body>"`;
 
 exports[`addStyle should work with "insert" option #3 1`] = `"<head><title>Title</title></head><body><h1>Hello world</h1><iframe class=\\"iframeTarget\\"></iframe></body>"`;

--- a/test/runtime/injectStylesIntoStyleTag.test.js
+++ b/test/runtime/injectStylesIntoStyleTag.test.js
@@ -792,4 +792,19 @@ describe('addStyle', () => {
 
     expect(document.documentElement.innerHTML).toMatchSnapshot();
   });
+
+  it('should work with "cssPostProcess"', () => {
+    document.body.innerHTML =
+      '<h1>Hello world</h1><div><div id="root" data-color="yellow"></div></div>';
+
+    injectStylesIntoStyleTag([['./style-44.css', '.foo { color: red }', '']], {
+      cssPostProcess: (css) => {
+        const rootElement = document.getElementById('root');
+        const color = rootElement.getAttribute('data-color');
+        return `${css} #root { color: ${color} }`;
+      },
+    });
+
+    expect(document.documentElement.innerHTML).toMatchSnapshot();
+  });
 });

--- a/test/validate-options.test.js
+++ b/test/validate-options.test.js
@@ -24,6 +24,10 @@ describe('validate options', () => {
       success: [true, false],
       failure: ['true'],
     },
+    cssPostProcess: {
+      success: [() => {}],
+      failure: [true, {}],
+    },
     unknown: {
       success: [],
       failure: [1, true, false, 'test', /test/, [], {}, { foo: 'bar' }],


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [x ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

When providing a theming option for customers, it is not practicable to build CSS assets for each and every single one of them, and that on a production server. Generating CSS with some placeholders and replacing them at runtime has proven to work nicely for us. The added runtime load is of course depending on how complex your want your runtime to be. In our case minimal.
We are currently working on prod with these patches and would now like to contribute the feature to the main stream.

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

none

### Additional Info
