### PR TITLE
refactor: removed support for loaders returning `String` instead of `…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -175,11 +175,7 @@ if (module.hot) {
               `!!${request}`
             )});
 
-            content = content.__esModule ? content.default : content;
-
-            if (typeof content === 'string') {
-              content = [[module.id, content, '']];
-            }`
+            content = content.__esModule ? content.default : content;`
       }
 
 var refs = 0;
@@ -301,11 +297,7 @@ if (module.hot) {
               `!!${request}`
             )});
 
-            content = content.__esModule ? content.default : content;
-
-            if (typeof content === 'string') {
-              content = [[module.id, content, '']];
-            }`
+            content = content.__esModule ? content.default : content;`
       }
 
 var options = ${JSON.stringify(runtimeOptions)};


### PR DESCRIPTION
…Array`

BREAKING CHANGE: removed support for loaders returning `String` instead of `Array`

<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

it is very old and limited in abilities (source maps/order)

### Breaking Changes

Yes

### Additional Info

No