### PR TITLE
feat: removed modules.namedExport option

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,14 +61,13 @@ module.exports = {
 
 ## Options
 
-|              Name               |         Type         |   Default   | Description                                              |
-| :-----------------------------: | :------------------: | :---------: | :------------------------------------------------------- |
-| [**`injectType`**](#injecttype) |      `{String}`      | `styleTag`  | Allows to setup how styles will be injected into the DOM |
-| [**`attributes`**](#attributes) |      `{Object}`      |    `{}`     | Adds custom attributes to tag                            |
-|     [**`insert`**](#insert)     | `{String\|Function}` |   `head`    | Inserts tag at the given position into the DOM           |
-|       [**`base`**](#base)       |      `{Number}`      |   `true`    | Sets module ID base (DLLPlugin)                          |
-|   [**`esModule`**](#esmodule)   |     `{Boolean}`      |   `true`    | Use ES modules syntax                                    |
-|    [**`modules`**](#modules)    |      `{Object}`      | `undefined` | Configuration CSS Modules                                |
+|              Name               |         Type         |  Default   | Description                                              |
+| :-----------------------------: | :------------------: | :--------: | :------------------------------------------------------- |
+| [**`injectType`**](#injecttype) |      `{String}`      | `styleTag` | Allows to setup how styles will be injected into the DOM |
+| [**`attributes`**](#attributes) |      `{Object}`      |    `{}`    | Adds custom attributes to tag                            |
+|     [**`insert`**](#insert)     | `{String\|Function}` |   `head`   | Inserts tag at the given position into the DOM           |
+|       [**`base`**](#base)       |      `{Number}`      |   `true`   | Sets module ID base (DLLPlugin)                          |
+|   [**`esModule`**](#esmodule)   |     `{Boolean}`      |   `true`   | Use ES modules syntax                                    |
 
 ### `injectType`
 
@@ -581,25 +580,15 @@ module.exports = {
 };
 ```
 
-### `modules`
+## Examples
 
-Type: `Object`
-Default: `undefined`
-
-Configuration CSS Modules.
-
-#### `namedExport`
-
-Type: `Boolean`
-Default: `false`
-
-Enables/disables ES modules named export for locals.
+### Configuration `namedExport` for CSS Modules
 
 > ⚠ Names of locals are converted to `camelCase`.
 
 > ⚠ It is not allowed to use JavaScript reserved words in css class names.
 
-> ⚠ Options `esModule` and `modules.namedExport` in `css-loader` and `style-loader` should be enabled.
+> ⚠ Options `esModule` and `modules.namedExport` in `css-loader` should be enabled.
 
 **styles.css**
 
@@ -635,9 +624,6 @@ module.exports = {
             loader: 'style-loader',
             options: {
               esModule: true,
-              modules: {
-                namedExport: true,
-              },
             },
           },
           {
@@ -655,8 +641,6 @@ module.exports = {
   },
 };
 ```
-
-## Examples
 
 ### Source maps
 

--- a/src/index.js
+++ b/src/index.js
@@ -26,8 +26,6 @@ loaderApi.pitch = function loader(request) {
   const injectType = options.injectType || 'styleTag';
   const esModule =
     typeof options.esModule !== 'undefined' ? options.esModule : true;
-  const namedExport =
-    esModule && options.modules && options.modules.namedExport;
   const runtimeOptions = {
     injectType: options.injectType,
     attributes: options.attributes,
@@ -103,25 +101,25 @@ ${esModule ? 'export default {}' : ''}`;
 
       const hmrCode = this.hot
         ? `
+var namedExport = Object.prototype.toString.call(locals) == "[object Module]"
+
 if (module.hot) {
   if (!content.locals || module.hot.invalidate) {
     var isEqualLocals = ${isEqualLocals.toString()};
-    var oldLocals = ${namedExport ? 'locals' : 'content.locals'};
+    var oldLocals = namedExport ? locals : content.locals;
 
     module.hot.accept(
       ${loaderUtils.stringifyRequest(this, `!!${request}`)},
       function () {
         ${
           esModule
-            ? `if (!isEqualLocals(oldLocals, ${
-                namedExport ? 'locals' : 'content.locals'
-              }, ${namedExport})) {
+            ? `if (!isEqualLocals(oldLocals, namedExport ? locals : content.locals, namedExport)) {
                 module.hot.invalidate();
 
                 return;
               }
 
-              oldLocals = ${namedExport ? 'locals' : 'content.locals'};
+              oldLocals = namedExport ? locals : content.locals;
 
               if (update && refs > 0) {
                 update(content);
@@ -163,9 +161,10 @@ if (module.hot) {
               this,
               `!${path.join(__dirname, 'runtime/injectStylesIntoStyleTag.js')}`
             )};
-            import content${
-              namedExport ? ', * as locals' : ''
-            } from ${loaderUtils.stringifyRequest(this, `!!${request}`)};`
+            import content, * as locals from ${loaderUtils.stringifyRequest(
+              this,
+              `!!${request}`
+            )};`
           : `var api = require(${loaderUtils.stringifyRequest(
               this,
               `!${path.join(__dirname, 'runtime/injectStylesIntoStyleTag.js')}`
@@ -187,7 +186,7 @@ options.singleton = ${isSingleton};
 
 var exported = {};
 
-${namedExport ? '' : 'exported.locals = content.locals || {};'}
+exported.locals = content.locals || {};
 exported.use = function() {
   if (!(refs++)) {
     update = api(content, options);
@@ -206,14 +205,7 @@ ${hmrCode}
 
 ${
   esModule
-    ? `${
-        namedExport
-          ? `export * from ${loaderUtils.stringifyRequest(
-              this,
-              `!!${request}`
-            )};`
-          : ''
-      };
+    ? `export * from ${loaderUtils.stringifyRequest(this, `!!${request}`)};
        export default exported;`
     : 'module.exports = exported;'
 }
@@ -227,25 +219,25 @@ ${
 
       const hmrCode = this.hot
         ? `
+var namedExport = Object.prototype.toString.call(locals) == "[object Module]"
+
 if (module.hot) {
   if (!content.locals || module.hot.invalidate) {
     var isEqualLocals = ${isEqualLocals.toString()};
-    var oldLocals = ${namedExport ? 'locals' : 'content.locals'};
+    var oldLocals = namedExport ? locals : content.locals;
 
     module.hot.accept(
       ${loaderUtils.stringifyRequest(this, `!!${request}`)},
       function () {
         ${
           esModule
-            ? `if (!isEqualLocals(oldLocals, ${
-                namedExport ? 'locals' : 'content.locals'
-              }, ${namedExport})) {
+            ? `if (!isEqualLocals(oldLocals, namedExport ? locals : content.locals, namedExport)) {
                 module.hot.invalidate();
 
                 return;
               }
 
-              oldLocals = ${namedExport ? 'locals' : 'content.locals'};
+              oldLocals = namedExport ? locals : content.locals;
 
               update(content);`
             : `content = require(${loaderUtils.stringifyRequest(
@@ -285,9 +277,10 @@ if (module.hot) {
               this,
               `!${path.join(__dirname, 'runtime/injectStylesIntoStyleTag.js')}`
             )};
-            import content${
-              namedExport ? ', * as locals' : ''
-            } from ${loaderUtils.stringifyRequest(this, `!!${request}`)};`
+            import content, * as locals from ${loaderUtils.stringifyRequest(
+              this,
+              `!!${request}`
+            )};`
           : `var api = require(${loaderUtils.stringifyRequest(
               this,
               `!${path.join(__dirname, 'runtime/injectStylesIntoStyleTag.js')}`
@@ -311,9 +304,8 @@ ${hmrCode}
 
 ${
   esModule
-    ? namedExport
-      ? `export * from ${loaderUtils.stringifyRequest(this, `!!${request}`)};`
-      : 'export default content.locals || {};'
+    ? `export * from ${loaderUtils.stringifyRequest(this, `!!${request}`)};
+       export default content.locals || {};`
     : 'module.exports = content.locals || {};'
 }`;
     }

--- a/src/options.json
+++ b/src/options.json
@@ -33,16 +33,6 @@
     "esModule": {
       "description": "Use the ES modules syntax (https://github.com/webpack-contrib/css-loader#esmodule).",
       "type": "boolean"
-    },
-    "modules": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "namedExport": {
-          "description": "Enables/disables ES modules named export for locals (https://webpack.js.org/plugins/mini-css-extract-plugin/#namedexport).",
-          "type": "boolean"
-        }
-      }
     }
   },
   "additionalProperties": false

--- a/test/__snapshots__/validate-options.test.js.snap
+++ b/test/__snapshots__/validate-options.test.js.snap
@@ -30,62 +30,50 @@ exports[`validate options should throw an error on the "insert" option with "tru
     * options.insert should be an instance of function."
 `;
 
-exports[`validate options should throw an error on the "modules" option with "true" value 1`] = `
-"Invalid options object. Style Loader has been initialized using an options object that does not match the API schema.
- - options.modules should be an object:
-   object { namedExport? }"
-`;
-
-exports[`validate options should throw an error on the "modules" option with "true" value 2`] = `
-"Invalid options object. Style Loader has been initialized using an options object that does not match the API schema.
- - options.modules should be an object:
-   object { namedExport? }"
-`;
-
 exports[`validate options should throw an error on the "unknown" option with "/test/" value 1`] = `
 "Invalid options object. Style Loader has been initialized using an options object that does not match the API schema.
  - options has an unknown property 'unknown'. These properties are valid:
-   object { injectType?, attributes?, insert?, base?, esModule?, modules? }"
+   object { injectType?, attributes?, insert?, base?, esModule? }"
 `;
 
 exports[`validate options should throw an error on the "unknown" option with "[]" value 1`] = `
 "Invalid options object. Style Loader has been initialized using an options object that does not match the API schema.
  - options has an unknown property 'unknown'. These properties are valid:
-   object { injectType?, attributes?, insert?, base?, esModule?, modules? }"
+   object { injectType?, attributes?, insert?, base?, esModule? }"
 `;
 
 exports[`validate options should throw an error on the "unknown" option with "{"foo":"bar"}" value 1`] = `
 "Invalid options object. Style Loader has been initialized using an options object that does not match the API schema.
  - options has an unknown property 'unknown'. These properties are valid:
-   object { injectType?, attributes?, insert?, base?, esModule?, modules? }"
+   object { injectType?, attributes?, insert?, base?, esModule? }"
 `;
 
 exports[`validate options should throw an error on the "unknown" option with "{}" value 1`] = `
 "Invalid options object. Style Loader has been initialized using an options object that does not match the API schema.
  - options has an unknown property 'unknown'. These properties are valid:
-   object { injectType?, attributes?, insert?, base?, esModule?, modules? }"
+   object { injectType?, attributes?, insert?, base?, esModule? }"
 `;
 
 exports[`validate options should throw an error on the "unknown" option with "1" value 1`] = `
 "Invalid options object. Style Loader has been initialized using an options object that does not match the API schema.
  - options has an unknown property 'unknown'. These properties are valid:
-   object { injectType?, attributes?, insert?, base?, esModule?, modules? }"
+   object { injectType?, attributes?, insert?, base?, esModule? }"
 `;
 
 exports[`validate options should throw an error on the "unknown" option with "false" value 1`] = `
 "Invalid options object. Style Loader has been initialized using an options object that does not match the API schema.
  - options has an unknown property 'unknown'. These properties are valid:
-   object { injectType?, attributes?, insert?, base?, esModule?, modules? }"
+   object { injectType?, attributes?, insert?, base?, esModule? }"
 `;
 
 exports[`validate options should throw an error on the "unknown" option with "test" value 1`] = `
 "Invalid options object. Style Loader has been initialized using an options object that does not match the API schema.
  - options has an unknown property 'unknown'. These properties are valid:
-   object { injectType?, attributes?, insert?, base?, esModule?, modules? }"
+   object { injectType?, attributes?, insert?, base?, esModule? }"
 `;
 
 exports[`validate options should throw an error on the "unknown" option with "true" value 1`] = `
 "Invalid options object. Style Loader has been initialized using an options object that does not match the API schema.
  - options has an unknown property 'unknown'. These properties are valid:
-   object { injectType?, attributes?, insert?, base?, esModule?, modules? }"
+   object { injectType?, attributes?, insert?, base?, esModule? }"
 `;

--- a/test/modules-option.test.js
+++ b/test/modules-option.test.js
@@ -34,7 +34,6 @@ describe('"modules" option', () => {
                     options: {
                       injectType,
                       esModule: true,
-                      modules: { namedExport: true },
                     },
                   },
                   {

--- a/test/validate-options.test.js
+++ b/test/validate-options.test.js
@@ -24,10 +24,6 @@ describe('validate options', () => {
       success: [true, false],
       failure: ['true'],
     },
-    modules: {
-      success: [{ namedExport: true }],
-      failure: [true, 'true'],
-    },
     unknown: {
       success: [],
       failure: [1, true, false, 'test', /test/, [], {}, { foo: 'bar' }],


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [x] **metadata update**

### Motivation / Use-Case

Removed `modules.namedExport` option in favor `modules.namedExport` option in [`css-loader`](https://github.com/webpack-contrib/css-loader)

### Breaking Changes

No

### Additional Info

No

