### PR TITLE
feat: removed modules.namedexport option

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,14 +61,13 @@ module.exports = {
 
 ## Options
 
-|              Name               |         Type         |   Default   | Description                                              |
-| :-----------------------------: | :------------------: | :---------: | :------------------------------------------------------- |
-| [**`injectType`**](#injecttype) |      `{String}`      | `styleTag`  | Allows to setup how styles will be injected into the DOM |
-| [**`attributes`**](#attributes) |      `{Object}`      |    `{}`     | Adds custom attributes to tag                            |
-|     [**`insert`**](#insert)     | `{String\|Function}` |   `head`    | Inserts tag at the given position into the DOM           |
-|       [**`base`**](#base)       |      `{Number}`      |   `true`    | Sets module ID base (DLLPlugin)                          |
-|   [**`esModule`**](#esmodule)   |     `{Boolean}`      |   `true`    | Use ES modules syntax                                    |
-|    [**`modules`**](#modules)    |      `{Object}`      | `undefined` | Configuration CSS Modules                                |
+|              Name               |         Type         |  Default   | Description                                              |
+| :-----------------------------: | :------------------: | :--------: | :------------------------------------------------------- |
+| [**`injectType`**](#injecttype) |      `{String}`      | `styleTag` | Allows to setup how styles will be injected into the DOM |
+| [**`attributes`**](#attributes) |      `{Object}`      |    `{}`    | Adds custom attributes to tag                            |
+|     [**`insert`**](#insert)     | `{String\|Function}` |   `head`   | Inserts tag at the given position into the DOM           |
+|       [**`base`**](#base)       |      `{Number}`      |   `true`   | Sets module ID base (DLLPlugin)                          |
+|   [**`esModule`**](#esmodule)   |     `{Boolean}`      |   `true`   | Use ES modules syntax                                    |
 
 ### `injectType`
 
@@ -581,25 +580,15 @@ module.exports = {
 };
 ```
 
-### `modules`
+## Examples
 
-Type: `Object`
-Default: `undefined`
-
-Configuration CSS Modules.
-
-#### `namedExport`
-
-Type: `Boolean`
-Default: `false`
-
-Enables/disables ES modules named export for locals.
+### Configuration `namedExport` for CSS Modules
 
 > ⚠ Names of locals are converted to `camelCase`.
 
 > ⚠ It is not allowed to use JavaScript reserved words in css class names.
 
-> ⚠ Options `esModule` and `modules.namedExport` in `css-loader` and `style-loader` should be enabled.
+> ⚠ Options `esModule` and `modules.namedExport` in `css-loader` should be enabled.
 
 **styles.css**
 
@@ -635,9 +624,6 @@ module.exports = {
             loader: 'style-loader',
             options: {
               esModule: true,
-              modules: {
-                namedExport: true,
-              },
             },
           },
           {
@@ -655,8 +641,6 @@ module.exports = {
   },
 };
 ```
-
-## Examples
 
 ### Source maps
 

--- a/src/index.js
+++ b/src/index.js
@@ -145,8 +145,7 @@ if (module.hot) {
               this,
               `!!${request}`
             )};
-
-            namedExport = Object.keys(locals).length > 1;
+            namedExport = !("locals" in locals.default);
             `
           : `var api = require(${stringifyRequest(
               this,
@@ -260,7 +259,7 @@ if (module.hot) {
               this,
               `!!${request}`
             )};
-            namedExport = Object.keys(locals).length > 1 ;
+            namedExport = !("locals" in locals.default);
             `
           : `var api = require(${stringifyRequest(
               this,

--- a/src/index.js
+++ b/src/index.js
@@ -88,20 +88,21 @@ ${esModule ? 'export default {}' : ''}`;
 if (module.hot) {
   if (!content.locals || module.hot.invalidate) {
     var isEqualLocals = ${isEqualLocals.toString()};
-    var oldLocals = namedExport ? locals : content.locals;
+    var isNamedExport = ${esModule ? "!('locals' in content)" : false};
+    var oldLocals = isNamedExport ? namedExport : content.locals;
 
     module.hot.accept(
       ${stringifyRequest(this, `!!${request}`)},
       function () {
         ${
           esModule
-            ? `if (!isEqualLocals(oldLocals, namedExport ? locals : content.locals, namedExport)) {
+            ? `if (!isEqualLocals(oldLocals, isNamedExport ? namedExport : content.locals, isNamedExport)) {
                 module.hot.invalidate();
 
                 return;
               }
 
-              oldLocals = namedExport ? locals : content.locals;
+              oldLocals = isNamedExport ? namedExport : content.locals;
 
               if (update && refs > 0) {
                 update(content);
@@ -134,18 +135,22 @@ if (module.hot) {
 }`
         : '';
 
-      return `var namedExport;
+      return `
+      var exported = {};
       ${
         esModule
           ? `import api from ${stringifyRequest(
               this,
               `!${path.join(__dirname, 'runtime/injectStylesIntoStyleTag.js')}`
             )};
-            import content, * as locals from ${stringifyRequest(
+            import content, * as namedExport from ${stringifyRequest(
               this,
               `!!${request}`
             )};
-            namedExport = !("locals" in locals.default);
+            
+            if ("locals" in content) {
+              exported.locals = content.locals || {};
+            }
             `
           : `var api = require(${stringifyRequest(
               this,
@@ -153,7 +158,10 @@ if (module.hot) {
             )});
             var content = require(${stringifyRequest(this, `!!${request}`)});
 
-            content = content.__esModule ? content.default : content;`
+            content = content.__esModule ? content.default : content;
+            
+            exported.locals = content.locals || {};
+            `
       }
 
 var refs = 0;
@@ -162,12 +170,6 @@ var options = ${JSON.stringify(runtimeOptions)};
 
 options.insert = ${insert};
 options.singleton = ${isSingleton};
-
-var exported = {};
-
-if (!namedExport) {
-  exported.locals = content.locals || {};
-}
 
 exported.use = function() {
   if (!(refs++)) {
@@ -204,20 +206,21 @@ ${
 if (module.hot) {
   if (!content.locals || module.hot.invalidate) {
     var isEqualLocals = ${isEqualLocals.toString()};
-    var oldLocals = namedExport ? locals : content.locals;
+    var isNamedExport = ${esModule ? "!('locals' in content)" : false};
+    var oldLocals = isNamedExport ? namedExport : content.locals;
 
     module.hot.accept(
       ${stringifyRequest(this, `!!${request}`)},
       function () {
         ${
           esModule
-            ? `if (!isEqualLocals(oldLocals, namedExport ? locals : content.locals, namedExport)) {
+            ? `if (!isEqualLocals(oldLocals, isNamedExport ? namedExport : content.locals, isNamedExport)) {
                 module.hot.invalidate();
 
                 return;
               }
 
-              oldLocals = namedExport ? locals : content.locals;
+              oldLocals = isNamedExport ? namedExport : content.locals;
 
               update(content);`
             : `content = require(${stringifyRequest(this, `!!${request}`)});
@@ -248,19 +251,17 @@ if (module.hot) {
 }`
         : '';
 
-      return `var namedExport;
+      return `
       ${
         esModule
           ? `import api from ${stringifyRequest(
               this,
               `!${path.join(__dirname, 'runtime/injectStylesIntoStyleTag.js')}`
             )};
-            import content, * as locals from ${stringifyRequest(
+            import content, * as namedExport from ${stringifyRequest(
               this,
               `!!${request}`
-            )};
-            namedExport = !("locals" in locals.default);
-            `
+            )};`
           : `var api = require(${stringifyRequest(
               this,
               `!${path.join(__dirname, 'runtime/injectStylesIntoStyleTag.js')}`

--- a/src/options.json
+++ b/src/options.json
@@ -34,16 +34,6 @@
     "esModule": {
       "description": "Use the ES modules syntax (https://github.com/webpack-contrib/css-loader#esmodule).",
       "type": "boolean"
-    },
-    "modules": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "namedExport": {
-          "description": "Enables/disables ES modules named export for locals (https://webpack.js.org/plugins/mini-css-extract-plugin/#namedexport).",
-          "type": "boolean"
-        }
-      }
     }
   },
   "additionalProperties": false

--- a/test/__snapshots__/validate-options.test.js.snap
+++ b/test/__snapshots__/validate-options.test.js.snap
@@ -30,62 +30,50 @@ exports[`validate options should throw an error on the "insert" option with "tru
     * options.insert should be an instance of function."
 `;
 
-exports[`validate options should throw an error on the "modules" option with "true" value 1`] = `
-"Invalid options object. Style Loader has been initialized using an options object that does not match the API schema.
- - options.modules should be an object:
-   object { namedExport? }"
-`;
-
-exports[`validate options should throw an error on the "modules" option with "true" value 2`] = `
-"Invalid options object. Style Loader has been initialized using an options object that does not match the API schema.
- - options.modules should be an object:
-   object { namedExport? }"
-`;
-
 exports[`validate options should throw an error on the "unknown" option with "/test/" value 1`] = `
 "Invalid options object. Style Loader has been initialized using an options object that does not match the API schema.
  - options has an unknown property 'unknown'. These properties are valid:
-   object { injectType?, attributes?, insert?, base?, esModule?, modules? }"
+   object { injectType?, attributes?, insert?, base?, esModule? }"
 `;
 
 exports[`validate options should throw an error on the "unknown" option with "[]" value 1`] = `
 "Invalid options object. Style Loader has been initialized using an options object that does not match the API schema.
  - options has an unknown property 'unknown'. These properties are valid:
-   object { injectType?, attributes?, insert?, base?, esModule?, modules? }"
+   object { injectType?, attributes?, insert?, base?, esModule? }"
 `;
 
 exports[`validate options should throw an error on the "unknown" option with "{"foo":"bar"}" value 1`] = `
 "Invalid options object. Style Loader has been initialized using an options object that does not match the API schema.
  - options has an unknown property 'unknown'. These properties are valid:
-   object { injectType?, attributes?, insert?, base?, esModule?, modules? }"
+   object { injectType?, attributes?, insert?, base?, esModule? }"
 `;
 
 exports[`validate options should throw an error on the "unknown" option with "{}" value 1`] = `
 "Invalid options object. Style Loader has been initialized using an options object that does not match the API schema.
  - options has an unknown property 'unknown'. These properties are valid:
-   object { injectType?, attributes?, insert?, base?, esModule?, modules? }"
+   object { injectType?, attributes?, insert?, base?, esModule? }"
 `;
 
 exports[`validate options should throw an error on the "unknown" option with "1" value 1`] = `
 "Invalid options object. Style Loader has been initialized using an options object that does not match the API schema.
  - options has an unknown property 'unknown'. These properties are valid:
-   object { injectType?, attributes?, insert?, base?, esModule?, modules? }"
+   object { injectType?, attributes?, insert?, base?, esModule? }"
 `;
 
 exports[`validate options should throw an error on the "unknown" option with "false" value 1`] = `
 "Invalid options object. Style Loader has been initialized using an options object that does not match the API schema.
  - options has an unknown property 'unknown'. These properties are valid:
-   object { injectType?, attributes?, insert?, base?, esModule?, modules? }"
+   object { injectType?, attributes?, insert?, base?, esModule? }"
 `;
 
 exports[`validate options should throw an error on the "unknown" option with "test" value 1`] = `
 "Invalid options object. Style Loader has been initialized using an options object that does not match the API schema.
  - options has an unknown property 'unknown'. These properties are valid:
-   object { injectType?, attributes?, insert?, base?, esModule?, modules? }"
+   object { injectType?, attributes?, insert?, base?, esModule? }"
 `;
 
 exports[`validate options should throw an error on the "unknown" option with "true" value 1`] = `
 "Invalid options object. Style Loader has been initialized using an options object that does not match the API schema.
  - options has an unknown property 'unknown'. These properties are valid:
-   object { injectType?, attributes?, insert?, base?, esModule?, modules? }"
+   object { injectType?, attributes?, insert?, base?, esModule? }"
 `;

--- a/test/manual/webpack.config.js
+++ b/test/manual/webpack.config.js
@@ -175,9 +175,6 @@ module.exports = {
             loader: require.resolve('../../dist/cjs.js'),
             options: {
               esModule: true,
-              modules: {
-                namedExport: true,
-              },
             },
           },
           {
@@ -200,9 +197,6 @@ module.exports = {
             options: {
               injectType: 'lazyStyleTag',
               esModule: true,
-              modules: {
-                namedExport: true,
-              },
             },
           },
           {

--- a/test/modules-option.test.js
+++ b/test/modules-option.test.js
@@ -34,7 +34,6 @@ describe('"modules" option', () => {
                     options: {
                       injectType,
                       esModule: true,
-                      modules: { namedExport: true },
                     },
                   },
                   {

--- a/test/validate-options.test.js
+++ b/test/validate-options.test.js
@@ -24,10 +24,6 @@ describe('validate options', () => {
       success: [true, false],
       failure: ['true'],
     },
-    modules: {
-      success: [{ namedExport: true }],
-      failure: [true, 'true'],
-    },
     unknown: {
       success: [],
       failure: [1, true, false, 'test', /test/, [], {}, { foo: 'bar' }],


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [x] **metadata update**

### Motivation / Use-Case

Removed `modules.namedExport` option in favor `modules.namedExport` option in [`css-loader`](https://github.com/webpack-contrib/css-loader)

### Breaking Changes

Yes

### Additional Info

No

