### PR TITLE
fix: styleTagTransform function path added to buildDependencies

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -314,6 +314,8 @@ function getStyleTagTransformFnCode(
       `${options.styleTagTransform}`
     );
 
+    loaderContext.addBuildDependency(options.styleTagTransform);
+
     return esModule
       ? `import styleTagTransformFn from ${modulePath};`
       : `var styleTagTransformFn = require(${modulePath});`;

--- a/test/__snapshots__/styleTagTransform-option.test.js.snap
+++ b/test/__snapshots__/styleTagTransform-option.test.js.snap
@@ -1,5 +1,31 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`"styleTagTransform" option should "styleTagTransform" function path added to buildDependencies when injectType lazyStyleTag: DOM 1`] = `
+"<!DOCTYPE html><html><head>
+  <title>style-loader test</title>
+  <style id=\\"existing-style\\">.existing { color: yellow }</style>
+<style>body {
+  color: red;
+}
+.modify{}
+</style><style>h1 {
+  color: blue;
+}
+.modify{}
+</style></head>
+<body>
+  <h1>Body</h1>
+  <div class=\\"target\\"></div>
+  <iframe class=\\"iframeTarget\\"></iframe>
+
+
+</body></html>"
+`;
+
+exports[`"styleTagTransform" option should "styleTagTransform" function path added to buildDependencies when injectType lazyStyleTag: errors 1`] = `Array []`;
+
+exports[`"styleTagTransform" option should "styleTagTransform" function path added to buildDependencies when injectType lazyStyleTag: warnings 1`] = `Array []`;
+
 exports[`"styleTagTransform" option should work when the "styleTagTransform" option is not specify and injectType lazyStyleTag: DOM 1`] = `
 "<!DOCTYPE html><html><head>
   <title>style-loader test</title>

--- a/test/styleTagTransform-option.test.js
+++ b/test/styleTagTransform-option.test.js
@@ -99,4 +99,23 @@ describe('"styleTagTransform" option', () => {
     expect(getWarnings(stats)).toMatchSnapshot("warnings");
     expect(getErrors(stats)).toMatchSnapshot("errors");
   });
+
+  it(`should "styleTagTransform" function path added to buildDependencies when injectType lazyStyleTag`, async () => {
+    const styleTagTransformFn = require.resolve("./fixtures/styleTagTransform");
+    const entry = getEntryByInjectType("simple.js", "lazyStyleTag");
+    const compiler = getCompiler(entry, {
+      injectType: "lazyStyleTag",
+      styleTagTransform: styleTagTransformFn,
+    });
+    const stats = await compile(compiler);
+    const { buildDependencies } = stats.compilation;
+
+    runInJsDom("main.bundle.js", compiler, stats, (dom) => {
+      expect(dom.serialize()).toMatchSnapshot("DOM");
+    });
+
+    expect(buildDependencies.has(styleTagTransformFn)).toBe(true);
+    expect(getWarnings(stats)).toMatchSnapshot("warnings");
+    expect(getErrors(stats)).toMatchSnapshot("errors");
+  });
 });


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

When the `styleTagTransform` option is an absolute path to a function, it is added to the` buildDependencies`

### Breaking Changes

No

### Additional Info

No
