### PR TITLE
Add shadow-DOM option type for injectType

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Possible values:
 - `lazySingletonStyleTag`
 - `lazyAutoStyleTag`
 - `linkTag`
+- `ShadowDOM`
 
 #### `styleTag`
 
@@ -384,6 +385,56 @@ The loader generate this:
 ```html
 <link rel="stylesheet" href="path/to/style.css" />
 <link rel="stylesheet" href="path/to/other-styles.css" />
+```
+
+
+#### `ShadowDOM`
+
+Automatically injects styles into a runtime container.
+You can import that the style content and inject into the shadow-DOM container.
+
+**component.js**
+
+```js
+import "./styles.css";
+```
+
+**webpack.config.js**
+
+```js
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.css$/i,
+        use: [
+          { loader: "style-loader", options: { injectType: "shadowDOM" } },
+          "css-loader",
+        ],
+      },
+    ],
+  },
+};
+```
+
+**main.js**
+
+```js
+import component from 'component';
+import getCss from 'style-loader/dist/runtime/injectStyleInScript';
+
+class MyElement extends Element {
+    constructor() {
+        super();
+
+        const shadowContent = this.attachShadow({ mode: 'open' });  
+        const style = document.createElement('style');
+
+        style.innerHTML = getCss();
+        shadowContent.appendChild(style);
+    }
+}
+
 ```
 
 ### `attributes`

--- a/src/index.js
+++ b/src/index.js
@@ -18,6 +18,7 @@ import {
   getSetAttributesCode,
   getInsertOptionCode,
   getStyleTagTransformFnCode,
+  getScriptAPI,
 } from "./utils";
 
 import schema from "./options.json";
@@ -144,7 +145,21 @@ ${hmrCode}
 ${getExportLazyStyleCode(esModule, this, request)}
 `;
     }
+    case "shadowDOM": {
 
+      return `
+      ${getImportStyleContentCode(esModule, this, request)}
+      ${getScriptAPI(esModule, this)}
+      ${
+        esModule
+          ? ""
+          : `content = content.__esModule ? content.default : content;`
+      }
+      context.add(content);
+
+      ${esModule ? "export default {}" : ""}
+      `;
+    }
     case "styleTag":
     case "autoStyleTag":
     case "singletonStyleTag":

--- a/src/options.json
+++ b/src/options.json
@@ -12,7 +12,8 @@
         "lazyStyleTag",
         "lazySingletonStyleTag",
         "lazyAutoStyleTag",
-        "linkTag"
+        "linkTag",
+        "shadowDOM"
       ]
     },
     "attributes": {

--- a/src/runtime/injectStyleInScript.js
+++ b/src/runtime/injectStyleInScript.js
@@ -1,0 +1,10 @@
+var styles = [];
+
+// eslint-disable-next-line no-multi-assign
+exports = module.exports = function () {
+  return styles.join("\n");
+};
+
+exports.add = function (content) {
+  styles.push(content);
+};

--- a/src/utils.js
+++ b/src/utils.js
@@ -286,6 +286,17 @@ function getImportIsOldIECode(esModule, loaderContext) {
     : `var isOldIE = require(${modulePath});`;
 }
 
+function getScriptAPI(esModule, loaderContext) {
+  const modulePath = stringifyRequest(
+    loaderContext,
+    `!${path.join(__dirname, "runtime/injectStyleInScript.js")}`
+  );
+
+  return esModule
+    ? `import context from ${modulePath};`
+    : `var context = require(${modulePath});`;
+}
+
 function getStyleTagTransformFnCode(
   esModule,
   loaderContext,
@@ -400,4 +411,5 @@ export {
   getSetAttributesCode,
   getInsertOptionCode,
   getStyleTagTransformFnCode,
+  getScriptAPI
 };


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:
- [x] new **feature**

### Motivation / Use-Case
Extract styles and put into a container, then can injected into the shadow-DOM conainer
```js
import component from 'component';
import getCss from 'style-loader/dist/runtime/injectStyleInScript';

class MyElement extends Element {
    constructor() {
        super();
        const shadowContent = this.attachShadow({ mode: 'open' });  
        const style = document.createElement('style');
        style.innerHTML = getCss();
        shadowContent.appendChild(style);
    }
}
