### PR TITLE
fix: noop in environment without DOM API

### DIFF
--- a/src/runtime/injectStylesIntoLinkTag.js
+++ b/src/runtime/injectStylesIntoLinkTag.js
@@ -1,4 +1,8 @@
 module.exports = (url, options) => {
+  if (typeof document === "undefined") {
+    return () => {};
+  }
+
   options = options || {};
   options.attributes =
     typeof options.attributes === "object" ? options.attributes : {};

--- a/src/runtime/isOldIE.js
+++ b/src/runtime/isOldIE.js
@@ -8,7 +8,12 @@ function isOldIE() {
     // Tests for existence of standard globals is to allow style-loader
     // to operate correctly into non-standard environments
     // @see https://github.com/webpack-contrib/style-loader/issues/177
-    memo = Boolean(window && document && document.all && !window.atob);
+    memo = Boolean(
+      typeof window !== "undefined" &&
+        typeof document !== "undefined" &&
+        document.all &&
+        !window.atob
+    );
   }
 
   return memo;

--- a/src/runtime/singletonStyleDomAPI.js
+++ b/src/runtime/singletonStyleDomAPI.js
@@ -74,6 +74,12 @@ const singletonData = {
 
 /* istanbul ignore next  */
 function domAPI(options) {
+  if (typeof document === "undefined")
+    return {
+      update: () => {},
+      remove: () => {},
+    };
+
   // eslint-disable-next-line no-undef,no-use-before-define
   const styleIndex = singletonData.singletonCounter++;
   const styleElement =

--- a/src/runtime/styleDomAPI.js
+++ b/src/runtime/styleDomAPI.js
@@ -54,6 +54,13 @@ function removeStyleElement(styleElement) {
 
 /* istanbul ignore next  */
 function domAPI(options) {
+  if (typeof document === "undefined") {
+    return {
+      update: () => {},
+      remove: () => {},
+    };
+  }
+
   const styleElement = options.insertStyleElement(options);
 
   return {

--- a/test/__snapshots__/injectType-option.test.js.snap
+++ b/test/__snapshots__/injectType-option.test.js.snap
@@ -1,5 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`"injectType" option should work when the "injectType" option is "autoStyleTag" with non DOM environment: errors 1`] = `Array []`;
+
+exports[`"injectType" option should work when the "injectType" option is "autoStyleTag" with non DOM environment: warnings 1`] = `Array []`;
+
 exports[`"injectType" option should work when the "injectType" option is "autoStyleTag": DOM 1`] = `
 "<!DOCTYPE html><html><head>
   <title>style-loader test</title>
@@ -23,6 +27,10 @@ exports[`"injectType" option should work when the "injectType" option is "autoSt
 exports[`"injectType" option should work when the "injectType" option is "autoStyleTag": errors 1`] = `Array []`;
 
 exports[`"injectType" option should work when the "injectType" option is "autoStyleTag": warnings 1`] = `Array []`;
+
+exports[`"injectType" option should work when the "injectType" option is "lazyAutoStyleTag" with non DOM environment: errors 1`] = `Array []`;
+
+exports[`"injectType" option should work when the "injectType" option is "lazyAutoStyleTag" with non DOM environment: warnings 1`] = `Array []`;
 
 exports[`"injectType" option should work when the "injectType" option is "lazyAutoStyleTag": DOM 1`] = `
 "<!DOCTYPE html><html><head>
@@ -48,6 +56,10 @@ exports[`"injectType" option should work when the "injectType" option is "lazyAu
 
 exports[`"injectType" option should work when the "injectType" option is "lazyAutoStyleTag": warnings 1`] = `Array []`;
 
+exports[`"injectType" option should work when the "injectType" option is "lazySingletonStyleTag" with non DOM environment: errors 1`] = `Array []`;
+
+exports[`"injectType" option should work when the "injectType" option is "lazySingletonStyleTag" with non DOM environment: warnings 1`] = `Array []`;
+
 exports[`"injectType" option should work when the "injectType" option is "lazySingletonStyleTag": DOM 1`] = `
 "<!DOCTYPE html><html><head>
   <title>style-loader test</title>
@@ -71,6 +83,10 @@ h1 {
 exports[`"injectType" option should work when the "injectType" option is "lazySingletonStyleTag": errors 1`] = `Array []`;
 
 exports[`"injectType" option should work when the "injectType" option is "lazySingletonStyleTag": warnings 1`] = `Array []`;
+
+exports[`"injectType" option should work when the "injectType" option is "lazyStyleTag" with non DOM environment: errors 1`] = `Array []`;
+
+exports[`"injectType" option should work when the "injectType" option is "lazyStyleTag" with non DOM environment: warnings 1`] = `Array []`;
 
 exports[`"injectType" option should work when the "injectType" option is "lazyStyleTag": DOM 1`] = `
 "<!DOCTYPE html><html><head>
@@ -96,6 +112,10 @@ exports[`"injectType" option should work when the "injectType" option is "lazySt
 
 exports[`"injectType" option should work when the "injectType" option is "lazyStyleTag": warnings 1`] = `Array []`;
 
+exports[`"injectType" option should work when the "injectType" option is "linkTag" with non DOM environment: errors 1`] = `Array []`;
+
+exports[`"injectType" option should work when the "injectType" option is "linkTag" with non DOM environment: warnings 1`] = `Array []`;
+
 exports[`"injectType" option should work when the "injectType" option is "linkTag": DOM 1`] = `
 "<!DOCTYPE html><html><head>
   <title>style-loader test</title>
@@ -113,6 +133,10 @@ exports[`"injectType" option should work when the "injectType" option is "linkTa
 exports[`"injectType" option should work when the "injectType" option is "linkTag": errors 1`] = `Array []`;
 
 exports[`"injectType" option should work when the "injectType" option is "linkTag": warnings 1`] = `Array []`;
+
+exports[`"injectType" option should work when the "injectType" option is "singletonStyleTag" with non DOM environment: errors 1`] = `Array []`;
+
+exports[`"injectType" option should work when the "injectType" option is "singletonStyleTag" with non DOM environment: warnings 1`] = `Array []`;
 
 exports[`"injectType" option should work when the "injectType" option is "singletonStyleTag": DOM 1`] = `
 "<!DOCTYPE html><html><head>
@@ -137,6 +161,10 @@ h1 {
 exports[`"injectType" option should work when the "injectType" option is "singletonStyleTag": errors 1`] = `Array []`;
 
 exports[`"injectType" option should work when the "injectType" option is "singletonStyleTag": warnings 1`] = `Array []`;
+
+exports[`"injectType" option should work when the "injectType" option is "styleTag" with non DOM environment: errors 1`] = `Array []`;
+
+exports[`"injectType" option should work when the "injectType" option is "styleTag" with non DOM environment: warnings 1`] = `Array []`;
 
 exports[`"injectType" option should work when the "injectType" option is "styleTag": DOM 1`] = `
 "<!DOCTYPE html><html><head>

--- a/test/injectType-option.test.js
+++ b/test/injectType-option.test.js
@@ -1,11 +1,14 @@
 /* eslint-env browser */
 
+import vm from "vm";
+
 import {
   compile,
   getCompiler,
   getEntryByInjectType,
   getErrors,
   getWarnings,
+  readAsset,
   runInJsDom,
 } from "./helpers/index";
 
@@ -32,6 +35,26 @@ describe('"injectType" option', () => {
         expect(dom.serialize()).toMatchSnapshot("DOM");
       });
 
+      expect(getWarnings(stats)).toMatchSnapshot("warnings");
+      expect(getErrors(stats)).toMatchSnapshot("errors");
+    });
+
+    it(`should work when the "injectType" option is "${injectType}" with non DOM environment`, async () => {
+      const entry = getEntryByInjectType("simple.js", injectType);
+      const compiler = getCompiler(entry, { injectType });
+      const stats = await compile(compiler);
+      const code = readAsset("main.bundle.js", compiler, stats);
+      const script = new vm.Script(code);
+
+      let errored;
+
+      try {
+        script.runInContext(vm.createContext({ console }));
+      } catch (error) {
+        errored = error;
+      }
+
+      expect(errored).toBeUndefined();
       expect(getWarnings(stats)).toMatchSnapshot("warnings");
       expect(getErrors(stats)).toMatchSnapshot("errors");
     });


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

fixes https://github.com/webpack-contrib/style-loader/issues/595

### Breaking Changes

No

### Additional Info

Based on https://github.com/webpack-contrib/style-loader/compare/master...OlegWock:style-loader:master, but looks like we don't need to handle document here [src/runtime/insertBySelector.js](https://github.com/webpack-contrib/style-loader/compare/master...OlegWock:style-loader:master#diff-1dcb8874fcaa26075962961db1fe6dedc03bf24cf578233be979e1299086f223)